### PR TITLE
docs: fix mkdocs strict build and add docs validation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,27 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: false
 
+c  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --group docs
+
+      - name: Build docs
+        run: uv run mkdocs build --strict
+
   test-summary:
     needs: test
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ wheels/
 web/node_modules/
 /htmlcov/
 _sandbox/
+site/

--- a/docs/guides/project-organization.md
+++ b/docs/guides/project-organization.md
@@ -194,7 +194,7 @@ Problems:
 
 ## Real-World Example
 
-The [Yorkshire example](../../examples/yorkshire/) demonstrates this pattern at scale:
+The [Yorkshire example](https://github.com/renaudcepre/protest/tree/main/examples/yorkshire) demonstrates this pattern at scale:
 
 ```
 yorkshire/tests/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,5 +79,3 @@ nav:
       - Filters: internals/filters.md
       - Dependency Injection: internals/dependency-injection.md
       - Plugins: internals/plugins.md
-  - Design Docs:
-      - Fixture Scoping: architecture/fixture-scoping-design.md

--- a/uv.lock
+++ b/uv.lock
@@ -648,7 +648,7 @@ wheels = [
 
 [[package]]
 name = "protest"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },


### PR DESCRIPTION
Remove deleted fixture-scoping-design.md from nav, fix relative link to yorkshire example, add site/ to .gitignore, and add a docs build check to CI so broken docs block PRs before reaching main.