### PR TITLE
feat(evals)!: namespace dataclass scores per evaluator

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -330,7 +330,7 @@ protest eval evals.session:session --show-output
 Each case prints one line:
 
 ```
-✓   classify_ticket_struct[T011] (2ms) category_is_allowed=✓ summary_keyword_recall=1.00 …
+✓   classify_ticket_struct[T011] (2ms) category_check.allowed=✓ summary_check.recall=1.00 …
 ```
 
 After every suite, an aggregate-stats table summarizes the `Metric`

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -16,7 +16,7 @@ Evaluate LLM outputs with scored metrics and historical tracking.
 - [TaskResult (SUT Usage Tracking)](#taskresult-sut-usage-tracking)
 - [Usage Display](#usage-display)
 - [Evaluator Errors](#evaluator-errors)
-- [Name Collisions](#name-collisions)
+- [Score Namespacing](#score-namespacing)
 - [Multi-Model Sessions](#multi-model-sessions)
 - [CLI](#cli)
 - [Output](#output)
@@ -206,8 +206,8 @@ def word_overlap(ctx: EvalContext) -> OverlapMetrics:
 In the terminal, tracking evaluators show with `·` instead of `✓`/`✗`:
 
 ```
-✓  chatbot[lookup] (1.2s) keyword_recall=0.95 all_present=✓
-·  chatbot[lookup]         overlap=0.80
+✓  chatbot[lookup] (1.2s) keyword_check.recall=0.95 keyword_check.all_present=✓
+·  chatbot[lookup]         word_overlap.overlap=0.80
 ```
 
 ### Simple Evaluator
@@ -227,7 +227,7 @@ from protest.evals import Metric, Verdict, Reason
 
 @dataclass
 class KeywordScores:
-    keyword_recall: Annotated[float, Metric]
+    recall: Annotated[float, Metric]
     all_present: Annotated[bool, Verdict]
     detail: Annotated[str, Reason] = ""
 
@@ -236,11 +236,15 @@ def keyword_check(ctx: EvalContext, keywords: list[str], min_recall: float = 0.5
     found = [k for k in keywords if k.lower() in ctx.output.lower()]
     recall = len(found) / len(keywords)
     return KeywordScores(
-        keyword_recall=recall,
+        recall=recall,
         all_present=recall >= min_recall,
         detail=f"found {len(found)}/{len(keywords)}",
     )
 ```
+
+Scores surface namespaced by the evaluator's name (`keyword_check.recall`,
+`keyword_check.all_present`), so field names only need to be unique within
+their own dataclass.
 
 The threshold (`min_recall`) is a parameter of the evaluator, not a framework concept. The evaluator decides the verdict.
 
@@ -342,15 +346,19 @@ EvalCase(name="factual_accuracy_case", inputs="...", evaluators=[llm_judge(rubri
 
 | Evaluator | Params | Returns |
 |-----------|--------|---------|
-| `contains_keywords` | `keywords, min_recall=1.0` | `keyword_recall: float`, `all_keywords_present: bool` |
+| `contains_keywords` | `keywords, min_recall=1.0` | `recall: float`, `all_present: bool` |
 | `contains_expected` | `case_sensitive=False` | `bool` |
-| `does_not_contain` | `forbidden` | `no_forbidden_words: bool` |
+| `does_not_contain` | `forbidden` | `ok: bool` |
 | `not_empty` | — | `bool` |
 | `max_length` | `max_chars=500` | `conciseness: float`, `within_limit: bool` |
 | `min_length` | `min_chars=1` | `bool` |
 | `matches_regex` | `pattern` | `bool` |
-| `json_valid` | `required_keys=[]` | `valid_json: bool`, `has_required_keys: bool` |
+| `json_valid` | `required_keys=[]` | `valid: bool`, `has_required_keys: bool` |
 | `word_overlap` | — | `overlap: float` (tracking-only) |
+
+Dataclass fields surface as `<evaluator>.<field>` in scores — e.g.
+`contains_keywords.recall`, `json_valid.valid` (see
+[Score Namespacing](#score-namespacing)).
 
 ## Fixtures
 
@@ -525,36 +533,40 @@ If an evaluator raises an exception (e.g. LLM judge timeout), the case is marked
 
 > **Tip:** For non-deterministic evaluators (LLM judges), catch exceptions in the evaluator and return a verdict indicating failure rather than letting them propagate.
 
-## Name Collisions
+## Score Namespacing
 
-Each `Verdict` / `Metric` / `Reason` field name from a dataclass evaluator
-becomes a key in the per-case score dict (and in the history file). **Names
-must be unique across all evaluators that run on the same case.**
+Each `Verdict` / `Metric` / `Reason` field from a dataclass evaluator becomes
+a score named `<evaluator>.<field>` — e.g. `keyword_check.recall`.
+A bool evaluator's single verdict keeps the evaluator's bare name
+(`not_empty`). These names are the keys in the per-case score dict, the
+history file, and the markdown artifacts.
 
-If two evaluators emit a score under the same name (e.g. both have a
-`detail` field), ProTest raises `ScoreNameCollisionError` at runtime so the
-collision is loud instead of silently overwriting the duplicate. Rename the
-colliding field — typically by prefixing with the evaluator's concept:
+Because names are namespaced per evaluator, two evaluators on the same case
+can both declare plain `ok` / `detail` fields without clashing:
 
 ```python
 @dataclass
 class SummaryShape:
-    summary_well_formed: Annotated[bool, Verdict]
-    summary_detail: Annotated[str, Reason] = ""        # not just "detail"
+    well_formed: Annotated[bool, Verdict]
+    detail: Annotated[str, Reason] = ""    # → summary_shape.detail
 
 @dataclass
 class CategoryMatch:
-    category_matches: Annotated[bool, Verdict]
-    category_match_detail: Annotated[str, Reason] = ""  # not just "detail"
+    matches: Annotated[bool, Verdict]
+    detail: Annotated[str, Reason] = ""    # → category_match.detail
 ```
 
-Why no auto-prefix? An evaluator's score name is what users grep for in
-history, scripts, and the markdown artifacts. Auto-prefixing would mean the
-same evaluator's `accuracy` field changes name (`fact_check.accuracy` vs
-plain `accuracy`) depending on which other evaluators are wired in alongside
-it — silently breaking downstream consumers when a new evaluator is added.
-Failing loud and asking you to pick a stable, unique name keeps the score
-identifiers stable across configurations.
+Namespacing is unconditional: a score's full name depends only on its own
+evaluator, never on which other evaluators are wired in alongside it — so
+the identifiers you grep for in history and scripts stay stable when
+evaluators are added or removed.
+
+A collision is still possible in one case: the same evaluator name attached
+twice to one case (the same `@evaluator` function rebound with different
+kwargs, or two functions sharing a name). ProTest raises
+`ScoreNameCollisionError` at runtime so the duplicate is loud instead of
+silently overwriting the other's scores. Wrap each binding in its own named
+`@evaluator` function to give them distinct names.
 
 ## Multi-Model Sessions
 
@@ -618,19 +630,19 @@ Flags are independent and combinable: `-v --show-output --show-logs`.
 ### Default
 
 ```
-   ✓   chatbot[lookup] (1.2s) keyword_recall=1.00 all_keywords_present=✓
-   ✗   chatbot[math]: all_keywords_present=False
+   ✓   chatbot[lookup] (1.2s) keyword_check.recall=1.00 keyword_check.all_present=✓
+   ✗   chatbot[math]: keyword_check.all_present=False
        │ inputs: What is 2+2?
        │ output: The answer is 4.
        │ expected: 4
-       │ detail: found 0/1
+       │ keyword_check.detail: found 0/1
 
            Eval: chatbot (2 cases)
-┏━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓
-┃ Score           ┃ mean ┃  p50 ┃   p5 ┃  p95 ┃
-┡━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━┩
-│ keyword_recall  │ 0.50 │ 0.50 │ 0.00 │ 1.00 │
-└─────────────────┴──────┴──────┴──────┴──────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓
+┃ Score                        ┃ mean ┃  p50 ┃   p5 ┃  p95 ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━┩
+│ keyword_check.recall │ 0.50 │ 0.50 │ 0.00 │ 1.00 │
+└──────────────────────────────┴──────┴──────┴──────┴──────┘
   Passed: 1/2 (50.0%)
   Results: .protest/results/chatbot_20260329_091422
 ```

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -187,7 +187,13 @@ from protest.evals import Metric, Verdict, Reason
 
 Unannotated fields are ignored by the runner — free metadata.
 
-Returning `float`, `dict`, or any other non-dataclass/non-bool type raises `TypeError`.
+The return annotation is **required** and must be `bool` or a dataclass —
+`@evaluator` raises `TypeError` at decoration time otherwise (missing
+annotation, `-> float`, `-> X | None`, …). The annotation is the score
+contract: it determines the score names recorded in history and the keys
+of skipped placeholders, so it must also resolve at runtime — import the
+return type for real (not only under `TYPE_CHECKING`) and define it at
+module level.
 
 ### Tracking-Only Evaluators
 
@@ -641,7 +647,7 @@ Flags are independent and combinable: `-v --show-output --show-logs`.
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓
 ┃ Score                        ┃ mean ┃  p50 ┃   p5 ┃  p95 ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━┩
-│ keyword_check.recall │ 0.50 │ 0.50 │ 0.00 │ 1.00 │
+│ keyword_check.recall         │ 0.50 │ 0.50 │ 0.00 │ 1.00 │
 └──────────────────────────────┴──────┴──────┴──────┴──────┘
   Passed: 1/2 (50.0%)
   Results: .protest/results/chatbot_20260329_091422

--- a/protest/evals/evaluator.py
+++ b/protest/evals/evaluator.py
@@ -240,6 +240,21 @@ class Reason:
     """Annotate a str field as a reason displayed on failure."""
 
 
+def _annotated_score_field_names(cls: type) -> list[str]:
+    """Names of the Metric/Verdict/Reason-annotated fields of a dataclass."""
+    names = []
+    hints = get_type_hints(cls, include_extras=True)
+    for f in dataclasses.fields(cls):
+        ann = hints.get(f.name)
+        if ann is None or get_origin(ann) is not Annotated:
+            continue
+        for meta in get_args(ann)[1:]:
+            if isinstance(meta, type) and issubclass(meta, (Metric, Verdict, Reason)):
+                names.append(f.name)
+                break
+    return names
+
+
 def extract_scores_from_result(result: Any, evaluator_name: str) -> list[Any]:
     """Extract EvalScore instances from an evaluator result.
 
@@ -258,24 +273,10 @@ def extract_scores_from_result(result: Any, evaluator_name: str) -> list[Any]:
         return [EvalScore(name=evaluator_name, value=result)]
 
     if dataclasses.is_dataclass(result) and not isinstance(result, type):
-        scores = []
-        hints = get_type_hints(type(result), include_extras=True)
-        for f in dataclasses.fields(result):
-            ann = hints.get(f.name)
-            if ann is None or get_origin(ann) is not Annotated:
-                continue
-            for meta in get_args(ann)[1:]:
-                if isinstance(meta, type) and issubclass(
-                    meta, (Metric, Verdict, Reason)
-                ):
-                    scores.append(
-                        EvalScore(
-                            name=f"{evaluator_name}.{f.name}",
-                            value=getattr(result, f.name),
-                        )
-                    )
-                    break
-        return scores
+        return [
+            EvalScore(name=f"{evaluator_name}.{name}", value=getattr(result, name))
+            for name in _annotated_score_field_names(type(result))
+        ]
 
     type_name = type(result).__name__
     raise TypeError(f"Evaluator must return bool or dataclass, got {type_name}")
@@ -307,6 +308,28 @@ class Evaluator:
     @property
     def name(self) -> str:
         return self._name
+
+    def score_names(self) -> list[str]:
+        """Score names this evaluator emits, derived from its return annotation.
+
+        Mirrors `extract_scores_from_result` without running the evaluator:
+        a dataclass return annotation yields the namespaced
+        ``<name>.<field>`` names; anything else (bool, missing or
+        unresolvable annotation) yields the bare evaluator name. Used to
+        build skipped placeholders with the same keys as a real run, so
+        score keys stay stable whether or not a ShortCircuit fired.
+        """
+        try:
+            hints = get_type_hints(self._fn)
+        except NameError:
+            # Unresolvable annotation (e.g. TYPE_CHECKING-only import).
+            # Execution would still work — it reads type(result) — so the
+            # placeholder must not be stricter than the real run.
+            return [self._name]
+        ret = hints.get("return")
+        if isinstance(ret, type) and dataclasses.is_dataclass(ret):
+            return [f"{self._name}.{n}" for n in _annotated_score_field_names(ret)]
+        return [self._name]
 
     def __call__(self, **kwargs: Any) -> Evaluator:
         # Re-binding form: always returns a fresh clone. Returning `self`

--- a/protest/evals/evaluator.py
+++ b/protest/evals/evaluator.py
@@ -13,7 +13,7 @@ Plain callables are not accepted in ``evaluators=[...]``; use ``@evaluator``::
     @evaluator
     def contains_keywords(ctx: EvalContext, keywords: list[str]) -> ContainsKeywordsResult:
         found = sum(1 for k in keywords if k.lower() in ctx.output.lower())
-        return ContainsKeywordsResult(keyword_recall=found / len(keywords), ...)
+        return ContainsKeywordsResult(recall=found / len(keywords), ...)
 
     # Bind params → returns a fresh Evaluator with kwargs frozen in.
     evaluators=[contains_keywords(keywords=["paris", "france"])]
@@ -245,7 +245,11 @@ def extract_scores_from_result(result: Any, evaluator_name: str) -> list[Any]:
 
     For bool returns: a single verdict named after the evaluator.
     For dataclass returns: only fields annotated with Metric/Verdict/Reason
-    are extracted. Unannotated fields are ignored (free metadata).
+    are extracted, each namespaced as ``<evaluator_name>.<field>`` so two
+    evaluators on the same case can both declare plain ``ok`` / ``detail``
+    fields. Namespacing is unconditional: a score's full name depends only
+    on its own evaluator, never on which other evaluators are wired in.
+    Unannotated fields are ignored (free metadata).
 
     Raises:
         TypeError: If result is not bool or dataclass.
@@ -264,7 +268,12 @@ def extract_scores_from_result(result: Any, evaluator_name: str) -> list[Any]:
                 if isinstance(meta, type) and issubclass(
                     meta, (Metric, Verdict, Reason)
                 ):
-                    scores.append(EvalScore(name=f.name, value=getattr(result, f.name)))
+                    scores.append(
+                        EvalScore(
+                            name=f"{evaluator_name}.{f.name}",
+                            value=getattr(result, f.name),
+                        )
+                    )
                     break
         return scores
 

--- a/protest/evals/evaluator.py
+++ b/protest/evals/evaluator.py
@@ -240,6 +240,39 @@ class Reason:
     """Annotate a str field as a reason displayed on failure."""
 
 
+def _validate_return_annotation(fn: Callable[..., Any]) -> None:
+    """Reject evaluator functions whose return annotation isn't bool or a dataclass.
+
+    The return annotation is the score contract: it determines the score
+    names recorded in history and the keys of skipped placeholders
+    (`Evaluator.score_names()`). An unannotated function — or one annotated
+    `-> X | None` / `-> Any` — would make the static derivation diverge
+    from what the run actually emits, silently reintroducing unstable
+    score keys. Failing at decoration time keeps the contract checkable.
+    """
+    try:
+        hints = get_type_hints(fn)
+    except NameError as exc:
+        raise TypeError(
+            f"@evaluator '{fn.__name__}': return annotation cannot be resolved "
+            f"at runtime ({exc}). Evaluator return types must resolve from "
+            f"module scope — import them at runtime (not only under "
+            f"TYPE_CHECKING) and define them at module level (a dataclass "
+            f"defined inside a function cannot be resolved). The annotation "
+            f"drives score names in history and skipped placeholders."
+        ) from exc
+    ret = hints.get("return")
+    base = get_origin(ret) or ret
+    if ret is bool or (isinstance(base, type) and dataclasses.is_dataclass(base)):
+        return
+    raise TypeError(
+        f"@evaluator '{fn.__name__}' must declare a return annotation of bool "
+        f"or a dataclass, got {ret!r}. The annotation is the score contract: "
+        f"it determines score names for history and skipped placeholders, so "
+        f"it cannot be missing, optional, or a union."
+    )
+
+
 def _annotated_score_field_names(cls: type) -> list[str]:
     """Names of the Metric/Verdict/Reason-annotated fields of a dataclass."""
     names = []
@@ -314,21 +347,16 @@ class Evaluator:
 
         Mirrors `extract_scores_from_result` without running the evaluator:
         a dataclass return annotation yields the namespaced
-        ``<name>.<field>`` names; anything else (bool, missing or
-        unresolvable annotation) yields the bare evaluator name. Used to
-        build skipped placeholders with the same keys as a real run, so
-        score keys stay stable whether or not a ShortCircuit fired.
+        ``<name>.<field>`` names; bool yields the bare evaluator name.
+        Used to build skipped placeholders with the same keys as a real
+        run, so score keys stay stable whether or not a ShortCircuit fired.
+        The annotation is guaranteed resolvable and bool-or-dataclass by
+        `_validate_return_annotation` at decoration time.
         """
-        try:
-            hints = get_type_hints(self._fn)
-        except NameError:
-            # Unresolvable annotation (e.g. TYPE_CHECKING-only import).
-            # Execution would still work — it reads type(result) — so the
-            # placeholder must not be stricter than the real run.
-            return [self._name]
-        ret = hints.get("return")
-        if isinstance(ret, type) and dataclasses.is_dataclass(ret):
-            return [f"{self._name}.{n}" for n in _annotated_score_field_names(ret)]
+        ret = get_type_hints(self._fn).get("return")
+        base = get_origin(ret) or ret
+        if isinstance(base, type) and dataclasses.is_dataclass(base):
+            return [f"{self._name}.{n}" for n in _annotated_score_field_names(base)]
         return [self._name]
 
     def __call__(self, **kwargs: Any) -> Evaluator:
@@ -360,5 +388,10 @@ def evaluator(fn: Callable[..., Any]) -> Evaluator:
     ``evaluators=[...]`` will accept. Plain callables are rejected at
     registration so the executor can rely on a uniform Union type instead
     of dispatching at runtime.
+
+    The function must declare a return annotation of ``bool`` or a
+    dataclass — the annotation is the score contract (see
+    `_validate_return_annotation`).
     """
+    _validate_return_annotation(fn)
     return Evaluator(fn)

--- a/protest/evals/evaluators.py
+++ b/protest/evals/evaluators.py
@@ -18,13 +18,13 @@ from protest.evals.evaluator import EvalContext, Metric, Verdict, evaluator
 
 @dataclass(frozen=True, slots=True)
 class ContainsKeywordsResult:
-    keyword_recall: Annotated[float, Metric]
-    all_keywords_present: Annotated[bool, Verdict]
+    recall: Annotated[float, Metric]
+    all_present: Annotated[bool, Verdict]
 
 
 @dataclass(frozen=True, slots=True)
 class DoesNotContainResult:
-    no_forbidden_words: Annotated[bool, Verdict]
+    ok: Annotated[bool, Verdict]
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,7 +35,7 @@ class MaxLengthResult:
 
 @dataclass(frozen=True, slots=True)
 class JsonValidResult:
-    valid_json: Annotated[bool, Verdict]
+    valid: Annotated[bool, Verdict]
     has_required_keys: Annotated[bool, Verdict]
 
 
@@ -60,8 +60,8 @@ def contains_keywords(
     total = len(keywords)
     recall = found / total if total else 1.0
     return ContainsKeywordsResult(
-        keyword_recall=recall,
-        all_keywords_present=recall >= min_recall,
+        recall=recall,
+        all_present=recall >= min_recall,
     )
 
 
@@ -82,7 +82,7 @@ def does_not_contain(
     """Check that the output does not contain forbidden words."""
     output = ctx.output if case_sensitive else ctx.output.lower()
     found = [w for w in forbidden if (w if case_sensitive else w.lower()) in output]
-    return DoesNotContainResult(no_forbidden_words=len(found) == 0)
+    return DoesNotContainResult(ok=len(found) == 0)
 
 
 @evaluator
@@ -135,14 +135,14 @@ def json_valid(
     try:
         parsed = json_module.loads(ctx.output)
     except (json_module.JSONDecodeError, TypeError):
-        return JsonValidResult(valid_json=False, has_required_keys=False)
+        return JsonValidResult(valid=False, has_required_keys=False)
 
     has_keys = (
         all(k in parsed for k in required_keys)
         if required_keys and isinstance(parsed, dict)
         else True
     )
-    return JsonValidResult(valid_json=True, has_required_keys=has_keys)
+    return JsonValidResult(valid=True, has_required_keys=has_keys)
 
 
 @evaluator

--- a/protest/evals/results_writer.py
+++ b/protest/evals/results_writer.py
@@ -130,6 +130,8 @@ def _format_case_duration(seconds: float) -> str:
 
 
 def _format_score(score: EvalScore) -> str:
+    if score.skipped:
+        return f"- **{score.name}**: skipped"
     icon = "·" if score.is_metric else ("✓" if score.passed else "✗")
     return f"- **{score.name}**: {score.value} {icon}"
 

--- a/protest/evals/types.py
+++ b/protest/evals/types.py
@@ -194,7 +194,7 @@ class EvalCaseResult:
             case_name=payload.case_name or "",
             node_id=result.node_id,
             scores=tuple(
-                EvalScore(name=name, value=entry.value)
+                EvalScore(name=name, value=entry.value, skipped=entry.skipped)
                 for name, entry in payload.scores.items()
             ),
             duration=payload.task_duration,

--- a/protest/evals/wrapper.py
+++ b/protest/evals/wrapper.py
@@ -71,6 +71,10 @@ def make_eval_wrapper(
         per_case = _extract_per_case_evaluators(kwargs)
         all_evaluators.extend(per_case)
 
+        # Duplicate evaluator names are knowable before running anything —
+        # fail here rather than after burning judge tokens on a doomed case.
+        _check_duplicate_evaluator_names(all_evaluators, case_name)
+
         scores, eval_ctx = await run_evaluators(
             all_evaluators,
             case_name,
@@ -82,10 +86,10 @@ def make_eval_wrapper(
             judge=judge,
         )
 
-        # Detect score-name collisions across evaluators. Names are
-        # namespaced per evaluator, so a duplicate means the same evaluator
-        # name appears twice on this case; EvalPayload.scores is a dict
-        # keyed by name and would silently drop one of them.
+        # Backstop for collisions the pre-execution name check can't see
+        # (e.g. two differently-named evaluators whose results emit the
+        # same score key). EvalPayload.scores is a dict keyed by name and
+        # would silently drop one of them.
         seen: set[str] = set()
         duplicates: list[str] = []
         for s in scores:
@@ -159,6 +163,38 @@ def _validate_single_evalcase_param(func: Any) -> None:
 # ---------------------------------------------------------------------------
 # Extract helpers — pull EvalCase from kwargs
 # ---------------------------------------------------------------------------
+
+
+def _check_duplicate_evaluator_names(
+    evaluators: list[Evaluator | ShortCircuit], case_name: str
+) -> None:
+    """Raise ScoreNameCollisionError if an evaluator name appears twice.
+
+    Score names are namespaced per evaluator, so a duplicate evaluator name
+    (the same @evaluator attached twice, possibly rebound with different
+    kwargs) guarantees colliding score keys. Runs before any evaluator —
+    including judge calls — executes.
+    """
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for ev in _flatten_evaluators(evaluators):
+        if ev.name in seen and ev.name not in duplicates:
+            duplicates.append(ev.name)
+        seen.add(ev.name)
+    if duplicates:
+        raise ScoreNameCollisionError(case_name, duplicates)
+
+
+def _flatten_evaluators(
+    evaluators: list[Evaluator | ShortCircuit],
+) -> list[Evaluator]:
+    flat: list[Evaluator] = []
+    for ev in evaluators:
+        if isinstance(ev, ShortCircuit):
+            flat.extend(ev.evaluators)
+        else:
+            flat.append(ev)
+    return flat
 
 
 def _find_case(kwargs: dict[str, Any]) -> EvalCase | None:
@@ -266,10 +302,14 @@ async def _run_short_circuit(
         extracted = extract_scores_from_result(result, ev.name)
         scores.extend(extracted)
         if any(s.is_verdict and not s.passed for s in extracted):
-            # Mark remaining evaluators as skipped
+            # Mark remaining evaluators as skipped. Placeholders carry the
+            # same namespaced keys a real run would emit, so score keys
+            # stay identical across runs whether the short-circuit fired
+            # or not (run-over-run history comparison relies on this).
             for skipped_ev in evaluators[i + 1 :]:
-                scores.append(
-                    EvalScore(name=skipped_ev.name, value=False, skipped=True)
+                scores.extend(
+                    EvalScore(name=score_name, value=False, skipped=True)
+                    for score_name in skipped_ev.score_names()
                 )
             break
     return scores

--- a/protest/evals/wrapper.py
+++ b/protest/evals/wrapper.py
@@ -86,10 +86,11 @@ def make_eval_wrapper(
             judge=judge,
         )
 
-        # Backstop for collisions the pre-execution name check can't see
-        # (e.g. two differently-named evaluators whose results emit the
-        # same score key). EvalPayload.scores is a dict keyed by name and
-        # would silently drop one of them.
+        # Defense-in-depth backstop. With per-evaluator namespacing and the
+        # pre-execution name check above, no known path reaches this —
+        # distinct evaluator names can't emit the same key. Kept because
+        # EvalPayload.scores is a dict: if a future extraction path ever
+        # produces duplicate keys, silent overwrite is the worst failure.
         seen: set[str] = set()
         duplicates: list[str] = []
         for s in scores:

--- a/protest/evals/wrapper.py
+++ b/protest/evals/wrapper.py
@@ -82,9 +82,10 @@ def make_eval_wrapper(
             judge=judge,
         )
 
-        # Detect score-name collisions across evaluators. EvalPayload.scores
-        # is a dict keyed by name; duplicates would silently overwrite each
-        # other downstream. Fail loud so the user can rename the field.
+        # Detect score-name collisions across evaluators. Names are
+        # namespaced per evaluator, so a duplicate means the same evaluator
+        # name appears twice on this case; EvalPayload.scores is a dict
+        # keyed by name and would silently drop one of them.
         seen: set[str] = set()
         duplicates: list[str] = []
         for s in scores:

--- a/protest/exceptions.py
+++ b/protest/exceptions.py
@@ -118,24 +118,23 @@ class MultipleEvalCaseParamsError(ProTestError):
 class ScoreNameCollisionError(ProTestError):
     """Raised when two evaluators in the same eval emit scores with the same name.
 
-    Each `EvalScore.name` (from a dataclass `Verdict`/`Metric`/`Reason` field
-    or from the evaluator's name when it returns `bool`) becomes a key in
-    `EvalPayload.scores` (a dict). If two evaluators emit the same name,
-    one would silently overwrite the other in the per-case report and history,
-    which is a real source of misleading data.
-
-    Fix by renaming the colliding fields so each Verdict/Metric/Reason has a
-    unique name within the suite (e.g. prefix with the evaluator's concept:
-    `summary_detail` instead of just `detail`).
+    Score names are namespaced by evaluator (`<evaluator>.<field>` for
+    dataclass results, the evaluator's name for bool results), so distinct
+    evaluators can freely share field names like `ok` or `detail`. A
+    collision therefore means the same evaluator name appears twice on one
+    case — e.g. the same `@evaluator` function attached twice (possibly with
+    different bound kwargs), or two functions sharing a `__name__`. The
+    duplicate scores would silently overwrite each other in the per-case
+    report and history, so we fail loud instead.
     """
 
     def __init__(self, case_name: str, duplicates: list[str]):
         dup_str = ", ".join(repr(d) for d in sorted(duplicates))
         super().__init__(
             f"Score-name collision in eval '{case_name}': {dup_str}. "
-            f"Two or more evaluators emit a score under the same name. "
-            f"Rename the colliding dataclass Verdict/Metric/Reason field(s) "
-            f"so each name is unique within the suite — otherwise the "
-            f"duplicate scores would silently overwrite each other in the "
-            f"per-case report and the history file."
+            f"Scores are namespaced per evaluator, so this means the same "
+            f"evaluator name appears more than once on this case — the same "
+            f"@evaluator attached twice (e.g. with different bound kwargs) "
+            f"or two functions sharing a name. Wrap each binding in its own "
+            f"named @evaluator function so every score name is unique."
         )

--- a/tests/evals/test_e2e.py
+++ b/tests/evals/test_e2e.py
@@ -321,7 +321,7 @@ class TestEvalOutput:
         assert len(reports) == 1
         stats = reports[0].all_score_stats()
         assert len(stats) > 0
-        assert any(s.name == "accuracy" for s in stats)
+        assert any(s.name == "fake_accuracy.accuracy" for s in stats)
 
     def test_report_has_pass_count(self) -> None:
         reports: list[EvalSuiteReport] = []
@@ -414,8 +414,8 @@ class TestEvalPayloadFlow:
             assert result.is_eval is True
             assert result.eval_payload is not None
             assert result.eval_payload.case_name in ("case_pass", "case_fail")
-            assert "accuracy" in result.eval_payload.scores
-            assert "matches_expected" in result.eval_payload.scores
+            assert "fake_accuracy.accuracy" in result.eval_payload.scores
+            assert "fake_accuracy.matches_expected" in result.eval_payload.scores
 
     def test_lifecycle_events_have_case_id_in_node_id(self) -> None:
         """setup_done/teardown_start events carry node_id with [case_id]."""
@@ -718,15 +718,15 @@ class TestBuiltinEvaluators:
     def test_contains_keywords(self) -> None:
         e = contains_keywords(keywords=["hello", "world"])
         result = e.run(self._make_ctx("Hello World"))
-        assert result.keyword_recall == 1.0
-        assert result.all_keywords_present is True
+        assert result.recall == 1.0
+        assert result.all_present is True
 
     def test_contains_keywords_default_requires_all(self) -> None:
         """Default `min_recall=1.0` means strict: missing one → verdict False."""
         e = contains_keywords(keywords=["hello", "world"])
         result = e.run(self._make_ctx("Only hello here"))
-        assert result.keyword_recall == 0.5
-        assert result.all_keywords_present is False
+        assert result.recall == 0.5
+        assert result.all_present is False
 
     def test_contains_keywords_threshold_continuity_at_zero(self) -> None:
         """Regression: `min_recall=0.0` must always pass (no discontinuity at 0).
@@ -737,22 +737,22 @@ class TestBuiltinEvaluators:
         """
         e = contains_keywords(keywords=["alpha", "beta"], min_recall=0.0)
         result = e.run(self._make_ctx("nothing matches"))
-        assert result.keyword_recall == 0.0
-        assert result.all_keywords_present is True
+        assert result.recall == 0.0
+        assert result.all_present is True
 
     def test_contains_keywords_threshold_at_exact_value(self) -> None:
         """Verdict passes when recall equals the threshold exactly."""
         e = contains_keywords(keywords=["alpha", "beta"], min_recall=0.5)
         result = e.run(self._make_ctx("only alpha here"))
-        assert result.keyword_recall == 0.5
-        assert result.all_keywords_present is True
+        assert result.recall == 0.5
+        assert result.all_present is True
 
     def test_contains_keywords_threshold_just_below(self) -> None:
         """Verdict fails when recall is below the threshold."""
         e = contains_keywords(keywords=["alpha", "beta", "gamma"], min_recall=0.5)
         result = e.run(self._make_ctx("only alpha"))
-        assert abs(result.keyword_recall - 1 / 3) < 1e-9
-        assert result.all_keywords_present is False
+        assert abs(result.recall - 1 / 3) < 1e-9
+        assert result.all_present is False
 
     def test_contains_expected(self) -> None:
         e = contains_expected
@@ -761,8 +761,8 @@ class TestBuiltinEvaluators:
 
     def test_does_not_contain(self) -> None:
         e = does_not_contain(forbidden=["cat", "dog"])
-        assert e.run(self._make_ctx("Yorkshire")).no_forbidden_words is True
-        assert e.run(self._make_ctx("I like cats")).no_forbidden_words is False
+        assert e.run(self._make_ctx("Yorkshire")).ok is True
+        assert e.run(self._make_ctx("I like cats")).ok is False
 
     def test_not_empty(self) -> None:
         assert not_empty.run(self._make_ctx("hello")) is True
@@ -826,10 +826,10 @@ class TestBuiltinEvaluators:
     def test_json_valid(self) -> None:
         e = json_valid(required_keys=["name"])
         result = e.run(self._make_ctx('{"name": "Rex"}'))
-        assert result.valid_json is True
+        assert result.valid is True
         assert result.has_required_keys is True
         result = e.run(self._make_ctx("not json"))
-        assert result.valid_json is False
+        assert result.valid is False
 
     def test_word_overlap(self) -> None:
         e = word_overlap

--- a/tests/evals/test_e2e.py
+++ b/tests/evals/test_e2e.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003 — used at runtime (pytest tmp_path)
 from typing import Annotated, Any
 
+import pytest
+
 from protest import ForEach, From, ProTestSession, Use, fixture
 from protest.api import run_session
 from protest.core.collector import Collector
@@ -919,40 +921,42 @@ class TestScoringV2:
         # word_overlap returns only float -> tracking-only, always passes
         assert result.success is True
 
-    def test_float_return_raises_type_error(self) -> None:
-        """Evaluator returning naked float -> TypeError (caught as fixture error)."""
-        results: list[Any] = []
+    def test_float_return_annotation_raises_at_decoration(self) -> None:
+        """`-> float` is rejected by @evaluator itself — the return annotation
+        is the score contract and must be bool or a dataclass."""
+        with pytest.raises(TypeError, match="bool or a dataclass"):
 
-        class Collector(PluginBase):
-            name = "collector"
+            @evaluator
+            def bad_evaluator(ctx: EvalContext) -> float:
+                return 0.5
 
-            def on_test_fail(self, result: Any) -> None:
-                results.append(result)
+    def test_missing_return_annotation_raises_at_decoration(self) -> None:
+        with pytest.raises(TypeError, match="bool or a dataclass"):
 
-        @evaluator
-        def bad_evaluator(ctx: EvalContext) -> float:
-            return 0.5
+            @evaluator
+            def unannotated(ctx: EvalContext):
+                return True
 
-        single_case = ForEach(
-            [EvalCase(inputs="hello", expected="hello", name="c1")],
-            ids=lambda c: c.name,
-        )
+    def test_optional_return_annotation_raises_at_decoration(self) -> None:
+        with pytest.raises(TypeError, match="bool or a dataclass"):
 
-        session = ProTestSession()
-        session.register_plugin(Collector())
+            @evaluator
+            def maybe(ctx: EvalContext) -> FakeAccuracyResult | None:
+                return None
 
-        eval_echo_suite = EvalSuite("eval_echo")
-        session.add_suite(eval_echo_suite)
+    def test_unresolvable_return_annotation_raises_at_decoration(self) -> None:
+        """A function-local dataclass can't be resolved by get_type_hints —
+        the placeholder keys would silently diverge from the real run."""
 
-        @eval_echo_suite.eval(evaluators=[bad_evaluator])
-        def eval_echo(case: Annotated[EvalCase, From(single_case)]) -> str:
-            return echo_task(case.inputs)
+        @dataclass
+        class LocalShape:
+            ok: Annotated[bool, Verdict]
 
-        runner = TestRunner(session)
-        runner.run()
+        with pytest.raises(TypeError, match="cannot be resolved"):
 
-        assert len(results) == 1
-        assert results[0].is_fixture_error is True
+            @evaluator
+            def local_shape(ctx: EvalContext) -> LocalShape:
+                return LocalShape(ok=True)
 
 
 class TestShortCircuit:

--- a/tests/evals/test_eval_case_result.py
+++ b/tests/evals/test_eval_case_result.py
@@ -77,6 +77,22 @@ class TestFromTestResultHappyPath:
         assert case.scores[0].name == "accuracy"
         assert case.scores[0].value == 0.9
 
+    def test_skipped_flag_preserved(self) -> None:
+        """Regression (#116): dropping `skipped` turned short-circuited
+        placeholders (value=False, skipped=True) into reported failures."""
+        payload = _make_payload(
+            scores={
+                "gate": EvalScoreEntry(value=False, passed=False),
+                "judge.ok": EvalScoreEntry(value=False, passed=True, skipped=True),
+            }
+        )
+        case = EvalCaseResult.from_test_result(_make_result(payload=payload))
+        by_name = {s.name: s for s in case.scores}
+        assert by_name["judge.ok"].skipped is True
+        assert by_name["judge.ok"].passed is True
+        assert by_name["judge.ok"] not in case.failed_scores
+        assert by_name["gate"] in case.failed_scores
+
     def test_task_usage_copied(self) -> None:
         """Regression: writer used to drop these fields silently."""
         case = EvalCaseResult.from_test_result(_make_result())

--- a/tests/evals/test_judge.py
+++ b/tests/evals/test_judge.py
@@ -25,6 +25,14 @@ from protest.plugin import PluginBase
 # ---------------------------------------------------------------------------
 
 
+@dataclass
+class JudgeVerdict:
+    """Module-level: @evaluator return annotations must resolve from module
+    scope (function-local dataclasses can't be resolved by get_type_hints)."""
+
+    ok: Annotated[bool, Verdict]
+
+
 class FakeJudge:
     """Minimal Judge implementation for tests."""
 
@@ -319,10 +327,6 @@ class TestJudgeE2E:
 
     def test_judge_with_structured_output(self) -> None:
         """Judge returns structured dataclass via output_type."""
-
-        @dataclass
-        class JudgeVerdict:
-            ok: Annotated[bool, Verdict]
 
         class StructuredJudge:
             name: str = "structured"

--- a/tests/evals/test_score_name_collision.py
+++ b/tests/evals/test_score_name_collision.py
@@ -134,8 +134,74 @@ class TestCollisionRaises:
         with pytest.raises(ScoreNameCollisionError) as excinfo:
             asyncio.run(_invoke([_shape_a, _shape_a], EvalCase(inputs="x", name="c3")))
         msg = str(excinfo.value)
-        assert "_shape_a.matches" in msg
+        assert "_shape_a" in msg
         assert "c3" in msg
+
+    def test_collision_detected_before_any_evaluator_runs(self) -> None:
+        """The name check fires pre-execution — no evaluator (judge) call is made."""
+        calls: list[str] = []
+
+        @evaluator
+        def _counting(ctx: EvalContext) -> bool:
+            calls.append("ran")
+            return True
+
+        with pytest.raises(ScoreNameCollisionError):
+            asyncio.run(
+                _invoke([_counting, _counting], EvalCase(inputs="x", name="c4"))
+            )
+        assert calls == []
+
+    def test_collision_inside_short_circuit_detected(self) -> None:
+        from protest.evals import ShortCircuit  # noqa: PLC0415
+
+        with pytest.raises(ScoreNameCollisionError):
+            asyncio.run(
+                _invoke(
+                    [_bool_one, ShortCircuit([_bool_one])],
+                    EvalCase(inputs="x", name="c5"),
+                )
+            )
+
+
+class TestSkippedPlaceholderNamespacing:
+    """Short-circuited evaluators emit placeholders under the same keys a
+    real run would produce, so score keys are stable across runs."""
+
+    def test_skipped_dataclass_evaluator_keeps_namespaced_keys(self) -> None:
+        from protest.evals import ShortCircuit  # noqa: PLC0415
+
+        @evaluator
+        def _gate(ctx: EvalContext) -> bool:
+            return False  # always short-circuits
+
+        payload = asyncio.run(
+            _invoke(
+                [ShortCircuit([_gate, _shape_a])],
+                EvalCase(inputs="x", name="c1"),
+            )
+        )
+        assert "_shape_a.matches" in payload.scores
+        assert "_shape_a.detail" in payload.scores
+        assert payload.scores["_shape_a.matches"].skipped is True
+        # Bare evaluator name must NOT appear — that was the pre-namespacing key.
+        assert "_shape_a" not in payload.scores
+
+    def test_skipped_bool_evaluator_keeps_bare_name(self) -> None:
+        from protest.evals import ShortCircuit  # noqa: PLC0415
+
+        @evaluator
+        def _gate(ctx: EvalContext) -> bool:
+            return False
+
+        payload = asyncio.run(
+            _invoke(
+                [ShortCircuit([_gate, _bool_one])],
+                EvalCase(inputs="x", name="c1"),
+            )
+        )
+        assert "_bool_one" in payload.scores
+        assert payload.scores["_bool_one"].skipped is True
 
 
 class TestSessionPath:

--- a/tests/evals/test_score_name_collision.py
+++ b/tests/evals/test_score_name_collision.py
@@ -1,10 +1,10 @@
-"""Tests for `ScoreNameCollisionError` — fail-loud on duplicate score names.
+"""Tests for score namespacing and `ScoreNameCollisionError`.
 
-Two evaluators emitting a score under the same name (e.g. both have a
-``detail`` field on their dataclass return) would silently overwrite each
-other in ``EvalPayload.scores`` (a dict). The wrapper detects the
-collision at runtime and raises a clear error pointing at the duplicate
-name(s) so the user can rename the colliding field.
+Dataclass scores are namespaced per evaluator (``<evaluator>.<field>``),
+so two evaluators on the same case can both declare plain ``ok`` /
+``detail`` fields. A collision is still possible — and raises — when the
+same evaluator name appears twice on one case (the same ``@evaluator``
+attached twice, e.g. rebound with different kwargs).
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ class _ShapeA:
 @dataclass
 class _ShapeB:
     other_check: Annotated[bool, Verdict]
-    detail: Annotated[str, Reason] = ""  # collides with _ShapeA.detail
+    detail: Annotated[str, Reason] = ""  # same field name as _ShapeA — fine
 
 
 @evaluator
@@ -59,81 +59,94 @@ def _bool_one(ctx: EvalContext) -> bool:
 
 @dataclass
 class _ShapeWithBoolOneField:
-    _bool_one: Annotated[bool, Verdict]  # collides with _bool_one evaluator's name
+    _bool_one: Annotated[bool, Verdict]  # namespaced — no clash with _bool_one
 
 
 @evaluator
-def _shape_collides_with_bool(ctx: EvalContext) -> _ShapeWithBoolOneField:
+def _shape_with_bool_one_field(ctx: EvalContext) -> _ShapeWithBoolOneField:
     return _ShapeWithBoolOneField(_bool_one=True)
 
 
-@dataclass
-class _ShapeUniqueA:
-    matches_a: Annotated[bool, Verdict]
-    detail_a: Annotated[str, Reason] = ""
-
-
-@dataclass
-class _ShapeUniqueB:
-    matches_b: Annotated[bool, Verdict]
-    detail_b: Annotated[str, Reason] = ""
-
-
 @evaluator
-def _shape_unique_a(ctx: EvalContext) -> _ShapeUniqueA:
-    return _ShapeUniqueA(matches_a=True, detail_a="A")
+def _threshold(ctx: EvalContext, limit: int = 0) -> bool:
+    return len(str(ctx.output)) >= limit
 
 
-@evaluator
-def _shape_unique_b(ctx: EvalContext) -> _ShapeUniqueB:
-    return _ShapeUniqueB(matches_b=True, detail_b="B")
-
-
-def _invoke(evaluators: list, case: EvalCase) -> None:
+async def _invoke(evaluators: list, case: EvalCase):
     """Invoke the eval wrapper directly so collision exceptions propagate."""
 
     def task(case: EvalCase) -> str:
         return str(case.inputs)
 
     wrapped = make_eval_wrapper(task, evaluators)
-    asyncio.run(wrapped(case=case))
+    return await wrapped(case=case)
+
+
+class TestNamespacing:
+    def test_shared_field_names_do_not_collide(self) -> None:
+        payload = asyncio.run(
+            _invoke([_shape_a, _shape_b], EvalCase(inputs="x", name="c1"))
+        )
+        assert "_shape_a.detail" in payload.scores
+        assert "_shape_b.detail" in payload.scores
+        assert "_shape_a.matches" in payload.scores
+        assert "_shape_b.other_check" in payload.scores
+
+    def test_bool_evaluator_keeps_bare_name(self) -> None:
+        payload = asyncio.run(_invoke([_bool_one], EvalCase(inputs="x", name="c1")))
+        assert "_bool_one" in payload.scores
+
+    def test_bool_name_does_not_clash_with_namespaced_field(self) -> None:
+        payload = asyncio.run(
+            _invoke(
+                [_bool_one, _shape_with_bool_one_field],
+                EvalCase(inputs="x", name="c2"),
+            )
+        )
+        assert "_bool_one" in payload.scores
+        assert "_shape_with_bool_one_field._bool_one" in payload.scores
 
 
 class TestCollisionRaises:
-    def test_two_dataclasses_share_field_name(self) -> None:
+    def test_same_bool_evaluator_twice(self) -> None:
         with pytest.raises(ScoreNameCollisionError) as excinfo:
-            _invoke([_shape_a, _shape_b], EvalCase(inputs="x", name="c1"))
-        msg = str(excinfo.value)
-        assert "'detail'" in msg
-        assert "c1" in msg
-
-    def test_bool_evaluator_name_collides_with_dataclass_field(self) -> None:
-        with pytest.raises(ScoreNameCollisionError) as excinfo:
-            _invoke(
-                [_bool_one, _shape_collides_with_bool],
-                EvalCase(inputs="x", name="c2"),
+            asyncio.run(
+                _invoke([_bool_one, _bool_one], EvalCase(inputs="x", name="c1"))
             )
         msg = str(excinfo.value)
         assert "_bool_one" in msg
+        assert "c1" in msg
+
+    def test_same_evaluator_rebound_with_different_kwargs(self) -> None:
+        # Rebinding keeps the function's name, so both emit '_threshold'.
+        with pytest.raises(ScoreNameCollisionError) as excinfo:
+            asyncio.run(
+                _invoke(
+                    [_threshold(limit=1), _threshold(limit=100)],
+                    EvalCase(inputs="x", name="c2"),
+                )
+            )
+        msg = str(excinfo.value)
+        assert "_threshold" in msg
         assert "c2" in msg
 
+    def test_same_dataclass_evaluator_twice(self) -> None:
+        with pytest.raises(ScoreNameCollisionError) as excinfo:
+            asyncio.run(_invoke([_shape_a, _shape_a], EvalCase(inputs="x", name="c3")))
+        msg = str(excinfo.value)
+        assert "_shape_a.matches" in msg
+        assert "c3" in msg
 
-class TestNoCollisionPasses:
-    def test_unique_names_pass(self) -> None:
-        # Should not raise.
-        _invoke(
-            [_shape_unique_a, _shape_unique_b],
-            EvalCase(inputs="x", name="c1"),
-        )
 
-    def test_session_with_unique_names_runs_clean(self) -> None:
-        """Smoke check: running through the full session path also succeeds."""
+class TestSessionPath:
+    def test_session_with_shared_field_names_runs_clean(self) -> None:
+        """Smoke check: shared `detail` fields pass through the full session."""
         from protest.api import run_session  # noqa: PLC0415 — heavy import
 
         session = ProTestSession()
         suite = EvalSuite("evals")
 
-        @suite.eval(evaluators=[_shape_unique_a, _shape_unique_b])
+        @suite.eval(evaluators=[_shape_a, _shape_b])
         def ok(case: Annotated[EvalCase, From(_cases)]) -> str:
             return str(case.inputs)
 


### PR DESCRIPTION
## Summary

Fixes #113. Fixes #116.

Dataclass `Verdict`/`Metric`/`Reason` fields now surface as `<evaluator>.<field>` (e.g. `keyword_check.recall`) instead of the bare field name, so two evaluators on the same case can both declare plain `ok`/`detail` fields. Bool evaluators keep their bare name.

Namespacing is **unconditional**: a score's full name depends only on its own evaluator, never on which other evaluators are wired in alongside it — identifiers stay stable across configurations. This answers the concern that previously justified rejecting auto-prefixing in the docs (which only applies to *conditional* prefixing triggered at collision time).

## Details

- Duplicate evaluator names are detected **before any evaluator runs** (suite + per-case merged, ShortCircuit flattened) — a doomed case fails before burning judge tokens. The post-execution check stays as a defense-in-depth backstop.
- ShortCircuit skipped placeholders emit the same namespaced keys a real run would produce (`Evaluator.score_names()`), so score keys are identical across runs whether the short-circuit fired or not.
- `@evaluator` validates at decoration time that the return annotation is resolvable and is bool or a dataclass — the annotation is the score contract, so a missing/optional/union annotation (which would make placeholder keys silently diverge from the real run) fails loud.
- `from_test_result` preserves the `skipped` flag (#116): short-circuited placeholders no longer render as ✗ in the markdown artifacts.
- Built-in evaluators drop their prefix workarounds: `contains_keywords` returns `recall`/`all_present`, `does_not_contain` returns `ok`, `json_valid` returns `valid`/`has_required_keys`.
- `eval_hash` (epoch cohorts) is computed from evaluator identity, not score names, so per-epoch history trends are unaffected; only the score keys in the JSONL change.
- Docs: *Name Collisions* rewritten as *Score Namespacing*; return-annotation contract documented; output examples and built-ins table updated.

## Migration

BREAKING CHANGE — history score keys and the evaluator contract change:

- Dataclass score keys: `<field>` → `<evaluator>.<field>`. History consumers see old and new keys as disjoint series.
- Built-in renames: `keyword_recall` → `contains_keywords.recall`, `all_keywords_present` → `contains_keywords.all_present`, `no_forbidden_words` → `does_not_contain.ok`, `valid_json` → `json_valid.valid`, `has_required_keys` → `json_valid.has_required_keys`.
- `@evaluator` functions must declare a return annotation of bool or a dataclass, resolvable at runtime from module scope (not only under `TYPE_CHECKING`, not function-local).

## Tests

- `test_score_name_collision.py` rewritten: namespacing, pre-execution collision detection (including inside ShortCircuit, with proof no evaluator ran), namespaced skipped placeholders.
- Return-annotation contract: decoration-time `TypeError` for `-> float`, missing annotation, `-> X | None`, unresolvable local dataclass.
- `skipped` preservation through `from_test_result`.
- Full suite: 1234 passed; lint and mypy clean.