### PR TITLE
chore: replace em dashes with plain hyphens across code and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Write your tests and your LLM evals in one async-first framework.**
 
-An eval is just a test that returns a value — scored, not asserted. Your evals get
+An eval is just a test that returns a value - scored, not asserted. Your evals get
 real fixtures, dependency injection and parallelism, and live right next to the
 tests they ship with. Python 3.10+, installs lean (Rich UI optional).
 
@@ -66,7 +66,7 @@ def test_status(code: Annotated[int, From(CODES)]): ...
 
 ### Native LLM Evals
 
-Score model outputs alongside your tests — same fixtures, same parallelism, same `protest` CLI. Cases get pass/fail + numeric metrics, persisted to JSONL for run-over-run comparison.
+Score model outputs alongside your tests - same fixtures, same parallelism, same `protest` CLI. Cases get pass/fail + numeric metrics, persisted to JSONL for run-over-run comparison.
 
 ```python
 from typing import Annotated

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -32,7 +32,7 @@ tests/
 3. **Fixtures live near their tests** - in the same file or a sibling `fixtures.py`
 4. **Nesting is meaningful** - `API::Users::Permissions` not arbitrary hierarchies
 
-> **Full guide:** [Project Organization](guides/project-organization.md) — multi-file patterns, anti-patterns, and a real-world walkthrough.
+> **Full guide:** [Project Organization](guides/project-organization.md) - multi-file patterns, anti-patterns, and a real-world walkthrough.
 
 ## Session Organization
 
@@ -91,7 +91,7 @@ import tests.test_users   # noqa: F401, E402
 import tests.test_orders   # noqa: F401, E402
 ```
 
-The imports are unused — they exist only to trigger `@suite.test()` registration at import time. This requires `# noqa` to silence linters and makes dependencies invisible. See the [Project Organization guide](guides/project-organization.md) for the correct pattern.
+The imports are unused - they exist only to trigger `@suite.test()` registration at import time. This requires `# noqa` to silence linters and makes dependencies invisible. See the [Project Organization guide](guides/project-organization.md) for the correct pattern.
 
 ## Suite Design
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -335,7 +335,7 @@ Each case prints one line:
 
 After every suite, an aggregate-stats table summarizes the `Metric`
 fields across cases (mean / p50 / p5 / p95). `Verdict` and `Reason`
-fields don't appear in this table — only numeric `Metric` fields do.
+fields don't appear in this table - only numeric `Metric` fields do.
 
 Per-case markdown artifacts are written to
 `.protest/results/<suite>_<timestamp>/<case-id>.md`, with the full

--- a/docs/core-concepts/console.md
+++ b/docs/core-concepts/console.md
@@ -45,5 +45,5 @@ The message is passed as-is to both reporters.
 `console.print` sends a `USER_PRINT` event through the event bus. The reporter receives it and writes to the real stdout (bypassing test capture). This means:
 
 - Messages appear immediately, not buffered until test end
-- Works with `-n 4` (concurrent tests) — the event bus serializes per plugin
+- Works with `-n 4` (concurrent tests) - the event bus serializes per plugin
 - No interference with test capture or `result.output`

--- a/docs/core-concepts/dependency-injection.md
+++ b/docs/core-concepts/dependency-injection.md
@@ -26,7 +26,7 @@ The `Use` marker takes a **function reference**, not a string. This makes depend
 
 ### `Type` is a hint, not a runtime check
 
-In `Annotated[Type, Use(fixture)]`, `Type` is a **type hint for your IDE and static checkers** — ProTest does not validate at runtime that `fixture()` actually returns a `Type`. This matches FastAPI's behavior with `Annotated[Type, Depends(fn)]`: the type is taken on faith, not enforced.
+In `Annotated[Type, Use(fixture)]`, `Type` is a **type hint for your IDE and static checkers** - ProTest does not validate at runtime that `fixture()` actually returns a `Type`. This matches FastAPI's behavior with `Annotated[Type, Depends(fn)]`: the type is taken on faith, not enforced.
 
 ```python
 @fixture()
@@ -35,7 +35,7 @@ def returns_str() -> str:
 
 @session.test()
 def test_mismatch(value: Annotated[int, Use(returns_str)]):
-    # `value` is actually a `str` at runtime — ProTest will not warn.
+    # `value` is actually a `str` at runtime - ProTest will not warn.
     # The mismatch surfaces only when `value` is used as an `int`.
     ...
 ```

--- a/docs/core-concepts/factories.md
+++ b/docs/core-concepts/factories.md
@@ -35,7 +35,7 @@ Key points:
 - Scope is determined by binding: `session.bind()` or `suite.bind()`
 - No binding = TEST scope (fresh factory per test)
 - The test receives a `FixtureFactory[T]`, not the value directly
-- Call the factory with `await` — it's always async
+- Call the factory with `await` - it's always async
 - Each call can pass different arguments
 
 > **Warning: Factory calls are always async**, even if the factory function itself is `def` (not `async def`). This means your test **must** be `async def` if it calls a factory. Internally, `FixtureFactory.__call__` is async because it uses `asyncio.Lock` for thread-safe caching.
@@ -43,7 +43,7 @@ Key points:
 ### Common Mistake: Calling a Factory From a Sync Test
 
 ```python
-# This will NOT work — factory() returns a coroutine, not T
+# This will NOT work - factory() returns a coroutine, not T
 @suite.test()
 def test_bad(f: Annotated[FixtureFactory[User], Use(user)]):
     u = f()  # u is a coroutine object, not a User!

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -25,17 +25,17 @@ Evaluate LLM outputs with scored metrics and historical tracking.
 
 ## What is an Eval?
 
-A test produces **pass/fail**. An eval produces **scores** — numeric values (0.0–1.0) that measure output quality. Scores are aggregated across cases, tracked over time, and compared between runs.
+A test produces **pass/fail**. An eval produces **scores** - numeric values (0.0–1.0) that measure output quality. Scores are aggregated across cases, tracked over time, and compared between runs.
 
 ProTest evals use the same infrastructure as tests: fixtures, DI, parallelism, tags. An eval is a test that returns a value, scored by evaluators.
 
 !!! tip "First-run expectations: don't expect 100% green"
 
-    Unlike tests, evals are **expected to have failing cases** — that's
+    Unlike tests, evals are **expected to have failing cases** - that's
     the signal you're measuring. `protest eval` still exits 1 when any
     case fails a `Verdict` (so CI surfaces regressions), but the
     failures are not bugs, they're data points. The aggregate-stats
-    table is designed for this — you watch the metrics drift over time.
+    table is designed for this - you watch the metrics drift over time.
     Every run is recorded to `.protest/history.jsonl` so the trend
     accumulates from day one (browsing and run-comparison tooling lands
     in a future release).
@@ -80,11 +80,11 @@ protest eval evals.session:session
 4. Bool verdicts determine pass/fail
 5. Aggregated stats appear in the terminal
 
-The rest of the pipeline — fixtures, DI, parallelism, reporters — works identically to tests.
+The rest of the pipeline - fixtures, DI, parallelism, reporters - works identically to tests.
 
 ## EvalSuite
 
-`EvalSuite` groups eval cases. It's the eval equivalent of `ProTestSuite` — it forces `kind=EVAL` and carries model/judge configuration. Model and judge are suite-level config: each suite declares which model produced its results and which judge scores them.
+`EvalSuite` groups eval cases. It's the eval equivalent of `ProTestSuite` - it forces `kind=EVAL` and carries model/judge configuration. Model and judge are suite-level config: each suite declares which model produced its results and which judge scores them.
 
 ```python
 from protest.evals import EvalSuite
@@ -100,7 +100,7 @@ async def chatbot(case: Annotated[EvalCase, From(cases)]) -> str:
 
 ## EvalCase
 
-Typed dataclass for eval case data. All eval cases **must** use `EvalCase` — plain dicts are not supported.
+Typed dataclass for eval case data. All eval cases **must** use `EvalCase` - plain dicts are not supported.
 
 ```python
 from protest.evals import EvalCase
@@ -117,12 +117,12 @@ cases = ForEach([
 | `expected` | `Any` | Expected output (passed to evaluators as `ctx.expected_output`) |
 | `name` | `str` | Case identifier (used in test IDs and history) |
 | `evaluators` | `list` | Per-case evaluators (added to suite-level ones) |
-| `tags` | `list[str]` | First-class tags — flow to `protest eval --tag …` (see below) |
+| `tags` | `list[str]` | First-class tags - flow to `protest eval --tag …` (see below) |
 | `metadata` | `dict` | Arbitrary metadata, opaque to the framework |
 
 ### Why `EvalCase` and not a dict?
 
-The runtime reads case data via attribute access (`case.expected`, `case.metadata`, `case.evaluators`), not by string key. A plain dict would compile fine but blow up at runtime, and you'd lose the IDE refactor/Ctrl+Click affordances. Making `EvalCase` a typed dataclass surfaces typos at import time and keeps the contract one obvious place — same trade-off as `Annotated[T, Use(fn)]` over pytest's name-based fixture lookup.
+The runtime reads case data via attribute access (`case.expected`, `case.metadata`, `case.evaluators`), not by string key. A plain dict would compile fine but blow up at runtime, and you'd lose the IDE refactor/Ctrl+Click affordances. Making `EvalCase` a typed dataclass surfaces typos at import time and keeps the contract one obvious place - same trade-off as `Annotated[T, Use(fn)]` over pytest's name-based fixture lookup.
 
 ### Per-case `tags`
 
@@ -145,7 +145,7 @@ protest eval evals.session:session --no-tag slow
 
 ## Evaluators
 
-An evaluator is a function decorated with `@evaluator` that receives an `EvalContext` and returns a verdict. The decorator is mandatory: passing a plain function in `evaluators=[...]` raises `TypeError` at registration. The wrapping is what gives the evaluator its identity (used for hashing, history, reporting) and a typed `run(ctx)` method — there's no implicit conversion.
+An evaluator is a function decorated with `@evaluator` that receives an `EvalContext` and returns a verdict. The decorator is mandatory: passing a plain function in `evaluators=[...]` raises `TypeError` at registration. The wrapping is what gives the evaluator its identity (used for hashing, history, reporting) and a typed `run(ctx)` method - there's no implicit conversion.
 
 !!! info "If your eval task returns a non-string output"
 
@@ -180,24 +180,24 @@ from protest.evals import Metric, Verdict, Reason
 
 | Annotation | Role |
 |------------|------|
-| `Annotated[bool, Verdict]` | Verdict — pass/fail (`all(verdicts)`) |
-| `Annotated[float, Metric]` | Metric — aggregated in stats (mean/p50/p95) |
-| `Annotated[int, Metric]` | Metric — converted to float |
-| `Annotated[str, Reason]` | Reason — displayed on failure, stored in history |
+| `Annotated[bool, Verdict]` | Verdict - pass/fail (`all(verdicts)`) |
+| `Annotated[float, Metric]` | Metric - aggregated in stats (mean/p50/p95) |
+| `Annotated[int, Metric]` | Metric - converted to float |
+| `Annotated[str, Reason]` | Reason - displayed on failure, stored in history |
 
-Unannotated fields are ignored by the runner — free metadata.
+Unannotated fields are ignored by the runner - free metadata.
 
-The return annotation is **required** and must be `bool` or a dataclass —
+The return annotation is **required** and must be `bool` or a dataclass -
 `@evaluator` raises `TypeError` at decoration time otherwise (missing
 annotation, `-> float`, `-> X | None`, …). The annotation is the score
 contract: it determines the score names recorded in history and the keys
-of skipped placeholders, so it must also resolve at runtime — import the
+of skipped placeholders, so it must also resolve at runtime - import the
 return type for real (not only under `TYPE_CHECKING`) and define it at
 module level.
 
 ### Tracking-Only Evaluators
 
-A dataclass with `Metric` fields but no `Verdict` is tracking-only. The case always passes for this evaluator — it measures without gating.
+A dataclass with `Metric` fields but no `Verdict` is tracking-only. The case always passes for this evaluator - it measures without gating.
 
 ```python
 @dataclass
@@ -274,7 +274,7 @@ async def llm_judge(ctx: EvalContext, rubric: str = "", min_score: float = 0.7) 
     )
 ```
 
-The judge handles structured output — no text parsing needed. See [Judge](#judge) for setup.
+The judge handles structured output - no text parsing needed. See [Judge](#judge) for setup.
 
 ### Per-Case Thresholds
 
@@ -295,15 +295,15 @@ from protest.evals import ShortCircuit
 evaluators=[
     not_empty,                                                  # always runs
     ShortCircuit([
-        contains_keywords(keywords=["paris"], min_recall=0.5),  # 0ms — if fail → stop
-        llm_judge(rubric="factual accuracy"),                   # 3s — skipped if above fails
+        contains_keywords(keywords=["paris"], min_recall=0.5),  # 0ms - if fail → stop
+        llm_judge(rubric="factual accuracy"),                   # 3s - skipped if above fails
     ]),
 ]
 ```
 
 `ShortCircuit` is a group of ordered evaluators. The first `Verdict=False` stops the group. Evaluators outside the `ShortCircuit` always run.
 
-Execution order — `evaluators=[a, ShortCircuit([b, c]), d]`:
+Execution order - `evaluators=[a, ShortCircuit([b, c]), d]`:
 
 ```
 a            ← always runs
@@ -355,14 +355,14 @@ EvalCase(name="factual_accuracy_case", inputs="...", evaluators=[llm_judge(rubri
 | `contains_keywords` | `keywords, min_recall=1.0` | `recall: float`, `all_present: bool` |
 | `contains_expected` | `case_sensitive=False` | `bool` |
 | `does_not_contain` | `forbidden` | `ok: bool` |
-| `not_empty` | — | `bool` |
+| `not_empty` | - | `bool` |
 | `max_length` | `max_chars=500` | `conciseness: float`, `within_limit: bool` |
 | `min_length` | `min_chars=1` | `bool` |
 | `matches_regex` | `pattern` | `bool` |
 | `json_valid` | `required_keys=[]` | `valid: bool`, `has_required_keys: bool` |
-| `word_overlap` | — | `overlap: float` (tracking-only) |
+| `word_overlap` | - | `overlap: float` (tracking-only) |
 
-Dataclass fields surface as `<evaluator>.<field>` in scores — e.g.
+Dataclass fields surface as `<evaluator>.<field>` in scores - e.g.
 `contains_keywords.recall`, `json_valid.valid` (see
 [Score Namespacing](#score-namespacing)).
 
@@ -392,7 +392,7 @@ async def pipeline_eval(
 
 ## ModelLabel
 
-`ModelLabel` is a **passive label** that ProTest stores in the history alongside each run, so you can attribute results to a specific model and compare runs side-by-side. It does not route requests, set a temperature, pick a provider, or otherwise touch any LLM — the actual model wiring happens inside *your* task function (or the agent / SDK it calls).
+`ModelLabel` is a **passive label** that ProTest stores in the history alongside each run, so you can attribute results to a specific model and compare runs side-by-side. It does not route requests, set a temperature, pick a provider, or otherwise touch any LLM - the actual model wiring happens inside *your* task function (or the agent / SDK it calls).
 
 ```python
 suite = EvalSuite("pipeline", model=ModelLabel(name="qwen-2.5"))
@@ -400,7 +400,7 @@ suite = EvalSuite("pipeline", model=ModelLabel(name="qwen-2.5"))
 
 ## Judge
 
-A `Judge` is a protocol for LLM-as-judge evaluators. ProTest owns the interface — you plug in your LLM library.
+A `Judge` is a protocol for LLM-as-judge evaluators. ProTest owns the interface - you plug in your LLM library.
 
 ### The Protocol
 
@@ -439,7 +439,7 @@ class PydanticAIJudge:
         )
 ```
 
-Tokens and cost are optional — omit them if your provider doesn't expose usage data:
+Tokens and cost are optional - omit them if your provider doesn't expose usage data:
 
 ```python
 return JudgeResponse(output=result.output)  # tokens/cost = None, that's fine
@@ -471,7 +471,7 @@ class JudgeResult:
 async def llm_rubric(ctx: EvalContext, rubric: str = "") -> JudgeResult:
     return await ctx.judge(
         f"Evaluate this response.\n\nResponse: {ctx.output}\nCriteria: {rubric}",
-        JudgeResult,  # structured output — no text parsing
+        JudgeResult,  # structured output - no text parsing
     )
 ```
 
@@ -519,7 +519,7 @@ async def chatbot(case: Annotated[EvalCase, From(cases)]) -> TaskResult[str]:
     )
 ```
 
-This is **opt-in** — returning a plain `str` still works. ProTest unwraps `TaskResult` transparently: evaluators see the plain output, usage stats flow to the reporter and history.
+This is **opt-in** - returning a plain `str` still works. ProTest unwraps `TaskResult` transparently: evaluators see the plain output, usage stats flow to the reporter and history.
 
 ## Usage Display
 
@@ -542,7 +542,7 @@ If an evaluator raises an exception (e.g. LLM judge timeout), the case is marked
 ## Score Namespacing
 
 Each `Verdict` / `Metric` / `Reason` field from a dataclass evaluator becomes
-a score named `<evaluator>.<field>` — e.g. `keyword_check.recall`.
+a score named `<evaluator>.<field>` - e.g. `keyword_check.recall`.
 A bool evaluator's single verdict keeps the evaluator's bare name
 (`not_empty`). These names are the keys in the per-case score dict, the
 history file, and the markdown artifacts.
@@ -563,7 +563,7 @@ class CategoryMatch:
 ```
 
 Namespacing is unconditional: a score's full name depends only on its own
-evaluator, never on which other evaluators are wired in alongside it — so
+evaluator, never on which other evaluators are wired in alongside it - so
 the identifiers you grep for in history and scripts stay stable when
 evaluators are added or removed.
 
@@ -629,7 +629,7 @@ protest eval evals.session:session --show-logs=DEBUG
 
 Flags are independent and combinable: `-v --show-output --show-logs`.
 
-> **Note:** Failed eval cases always show inputs/output/expected — no flag needed.
+> **Note:** Failed eval cases always show inputs/output/expected - no flag needed.
 
 ## Output
 
@@ -677,8 +677,8 @@ yourself in the meantime.
 
 Each case in history carries two hashes:
 
-- **`case_hash`** — hash of inputs + expected output. Changes when the test data changes.
-- **`eval_hash`** — hash of evaluators. Changes when the scoring criteria change.
+- **`case_hash`** - hash of inputs + expected output. Changes when the test data changes.
+- **`eval_hash`** - hash of evaluators. Changes when the scoring criteria change.
 
 These hashes are what lets a later comparison distinguish a real regression
 from a definition change: when a case's `eval_hash` differs between two runs,

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -55,5 +55,5 @@ your type checker at the right interpreter:
 - **mypy**: run via `uv run mypy ...` so it inherits the same
   interpreter, or set `python_executable` in `mypy.ini`.
 
-Once configured, no extra stub package or plugin is needed — protest
+Once configured, no extra stub package or plugin is needed - protest
 exposes its own types directly.

--- a/docs/guides/project-organization.md
+++ b/docs/guides/project-organization.md
@@ -62,7 +62,7 @@ def test_user_display_name() -> None:
     assert u.display_name == "Alice (member)"
 ```
 
-The `@suite.test()` decorators register tests at import time. The key is that `users_suite` is exported — another module will import and consume it.
+The `@suite.test()` decorators register tests at import time. The key is that `users_suite` is exported - another module will import and consume it.
 
 ### Step 2: Intermediate Suites Assemble Children
 
@@ -80,11 +80,11 @@ api_suite.add_suite(users_api_suite)
 api_suite.add_suite(orders_api_suite)
 ```
 
-Every import is immediately consumed by `.add_suite()` — no dead imports.
+Every import is immediately consumed by `.add_suite()` - no dead imports.
 
 ### Step 3: Session Assembles Everything
 
-The session file is thin — just imports and registration:
+The session file is thin - just imports and registration:
 
 ```python
 # tests/session.py
@@ -131,20 +131,20 @@ protest run tests.session:session -k "change_role"
 
 ## Why This Pattern Works
 
-1. **Every import is consumed** — `suite.add_suite()`, `session.bind()`, or `session.add_suite()` uses the imported object. No linter warnings, no `# noqa`.
+1. **Every import is consumed** - `suite.add_suite()`, `session.bind()`, or `session.add_suite()` uses the imported object. No linter warnings, no `# noqa`.
 
-2. **Clear ownership** — each test file owns its suite. You can read one file and understand what it tests.
+2. **Clear ownership** - each test file owns its suite. You can read one file and understand what it tests.
 
-3. **Composable** — suites nest naturally. `API::Users::Permissions` is just three files, each adding its suite to the parent.
+3. **Composable** - suites nest naturally. `API::Users::Permissions` is just three files, each adding its suite to the parent.
 
-4. **IDE-friendly** — "Go to Definition" on any suite import takes you to the file that defines it. Rename refactoring works.
+4. **IDE-friendly** - "Go to Definition" on any suite import takes you to the file that defines it. Rename refactoring works.
 
 ## Anti-Pattern: Side-Effect Imports
 
 When a test module doesn't export its suite but instead reaches into the session file to get it, you end up with side-effect imports:
 
 ```python
-# DON'T DO THIS — tests/session.py
+# DON'T DO THIS - tests/session.py
 from protest import ProTestSession, ProTestSuite
 
 session = ProTestSession()
@@ -157,7 +157,7 @@ import tests.domain.test_orders  # noqa: F401, E402
 ```
 
 ```python
-# tests/domain/test_users.py — reaches back into session
+# tests/domain/test_users.py - reaches back into session
 from tests.session import domain_suite  # circular risk!
 
 @domain_suite.test()
@@ -165,10 +165,10 @@ def test_something(): ...
 ```
 
 Problems:
-- **`# noqa` everywhere** — linters correctly warn about unused imports
-- **Circular import risk** — test modules import from session, session imports test modules
-- **Invisible dependencies** — removing an import silently drops tests with no error
-- **Import order matters** — suites must be defined before test modules are imported
+- **`# noqa` everywhere** - linters correctly warn about unused imports
+- **Circular import risk** - test modules import from session, session imports test modules
+- **Invisible dependencies** - removing an import silently drops tests with no error
+- **Import order matters** - suites must be defined before test modules are imported
 
 ## Anti-Pattern: One Session Per Test File
 
@@ -210,7 +210,7 @@ yorkshire/tests/
     └── ...
 ```
 
-The session file imports each suite and registers it — every import consumed, zero `# noqa`.
+The session file imports each suite and registers it - every import consumed, zero `# noqa`.
 
 ## Tips
 
@@ -224,6 +224,6 @@ The session file imports each suite and registers it — every import consumed, 
 
 ## See Also
 
-- [Best Practices](../best-practices.md) — fixture placement, naming conventions, tags
-- [Fixtures](../core-concepts/fixtures.md) — scope at binding, teardown
-- [Running Tests](../getting-started/running-tests.md) — CLI filters, tags, `--lf`
+- [Best Practices](../best-practices.md) - fixture placement, naming conventions, tags
+- [Fixtures](../core-concepts/fixtures.md) - scope at binding, teardown
+- [Running Tests](../getting-started/running-tests.md) - CLI filters, tags, `--lf`

--- a/docs/guides/testing-fastapi.md
+++ b/docs/guides/testing-fastapi.md
@@ -4,7 +4,7 @@ How to write async integration tests for a FastAPI application using ProTest, ht
 
 ## Async Client with Lifespan
 
-FastAPI's `TestClient` is synchronous. For ProTest's async-first approach, `httpx.AsyncClient` with `ASGITransport` is the natural fit — but **httpx does not trigger ASGI lifespan events**.
+FastAPI's `TestClient` is synchronous. For ProTest's async-first approach, `httpx.AsyncClient` with `ASGITransport` is the natural fit - but **httpx does not trigger ASGI lifespan events**.
 
 This means if your app uses `@asynccontextmanager` lifespan (the modern FastAPI pattern for startup/shutdown), your app state won't be initialized during tests:
 
@@ -23,7 +23,7 @@ app = FastAPI(lifespan=lifespan)
 ```
 
 ```python
-# This will NOT work — lifespan never runs, app.state.db is missing
+# This will NOT work - lifespan never runs, app.state.db is missing
 transport = httpx.ASGITransport(app=app)
 async with httpx.AsyncClient(transport=transport) as client:
     resp = await client.get("/users")  # 500: 'State' has no attribute 'db'
@@ -85,13 +85,13 @@ Bind it at the appropriate scope:
 # tests/session.py
 from tests.fixtures import client
 
-# SESSION scope — one client for all tests (fast, shared state)
+# SESSION scope - one client for all tests (fast, shared state)
 session.bind(client)
 
-# Or SUITE scope — fresh client per suite (isolated)
+# Or SUITE scope - fresh client per suite (isolated)
 api_suite.bind(client)
 
-# Or TEST scope (no binding) — fresh client per test (slowest, most isolated)
+# Or TEST scope (no binding) - fresh client per test (slowest, most isolated)
 ```
 
 ## Complete Example
@@ -250,20 +250,20 @@ async def client() -> AsyncIterator[httpx.AsyncClient]:
             yield c
 ```
 
-This works but is non-standard. Prefer `asgi-lifespan` — it handles edge cases (multiple lifespans, error propagation) that a manual wrapper misses.
+This works but is non-standard. Prefer `asgi-lifespan` - it handles edge cases (multiple lifespans, error propagation) that a manual wrapper misses.
 
 ## Why Not `TestClient`?
 
 FastAPI's `TestClient` (from Starlette) is synchronous and uses `requests` under the hood. It handles lifespan automatically, but:
 
-- **Sync-only** — doesn't work with ProTest's async tests
-- **Thread-based** — spawns a background thread for the event loop
-- **No concurrency** — can't benefit from ProTest's parallel execution
+- **Sync-only** - doesn't work with ProTest's async tests
+- **Thread-based** - spawns a background thread for the event loop
+- **No concurrency** - can't benefit from ProTest's parallel execution
 
 `httpx.AsyncClient` + `asgi-lifespan` gives you native async testing that composes naturally with ProTest.
 
 ## See Also
 
-- [Project Organization](project-organization.md) — how to structure test files
-- [Fixtures](../core-concepts/fixtures.md) — scope at binding, `yield` teardown
-- [Best Practices](../best-practices.md) — naming, tags, anti-patterns
+- [Project Organization](project-organization.md) - how to structure test files
+- [Fixtures](../core-concepts/fixtures.md) - scope at binding, `yield` teardown
+- [Best Practices](../best-practices.md) - naming, tags, anti-patterns

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ protest run tests:session -n 10
 **Ctrl+Click works.** Your IDE knows every type. No guessing where fixtures come from.
 
 ```python
-# pytest: "db" is resolved by name — requires searching through fixtures
+# pytest: "db" is resolved by name - requires searching through fixtures
 def test_user(db): ...
 
 # ProTest: Ctrl+Click → Go to definition. Full type inference.
@@ -30,7 +30,7 @@ def test_user(db: Annotated[Database, Use(database)]): ...
 
 ### Smart Tagging (Tag Propagation)
 
-Tag a fixture once, and **every test using it inherits the tag automatically**—even through deep dependency chains.
+Tag a fixture once, and **every test using it inherits the tag automatically** - even through deep dependency chains.
 
 ```python
 @fixture(tags=["database"])

--- a/examples/yorkshire/app/chatbot.py
+++ b/examples/yorkshire/app/chatbot.py
@@ -1,4 +1,4 @@
-"""Yorkshire Terrier Expert Chatbot — fake LLM for eval demos.
+"""Yorkshire Terrier Expert Chatbot - fake LLM for eval demos.
 
 Simulates a RAG chatbot with realistic imperfections:
 - Sometimes misses keywords (simulates retrieval failures)
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import random
 
-# Knowledge base — what a real RAG system would retrieve
+# Knowledge base - what a real RAG system would retrieve
 YORKSHIRE_FACTS = {
     "size": "Yorkshire Terriers typically weigh between 2-3 kg. They come in teacup, mini, and standard sizes.",
     "grooming": "Yorkies with long coats need daily brushing. Seniors over 6 years need extra grooming care. Regular baths every 2-3 weeks.",
@@ -29,7 +29,7 @@ def yorkshire_chatbot(question: str) -> str:  # noqa: PLR0912
     """Fake chatbot that answers questions about Yorkshire Terriers.
 
     Simulates a RAG pipeline: keyword matching → fact retrieval → response generation.
-    No LLM calls — pure string matching for deterministic eval testing.
+    No LLM calls - pure string matching for deterministic eval testing.
     """
     question_lower = question.lower()
 

--- a/examples/yorkshire/evals/session.py
+++ b/examples/yorkshire/evals/session.py
@@ -1,4 +1,4 @@
-"""Yorkshire Chatbot Evals — evaluate the fake Yorkshire expert chatbot.
+"""Yorkshire Chatbot Evals - evaluate the fake Yorkshire expert chatbot.
 
 Run with:
     protest eval examples.yorkshire.evals.session:session

--- a/examples/yorkshire/session.py
+++ b/examples/yorkshire/session.py
@@ -1,4 +1,4 @@
-"""Yorkshire Terrier Unified Session — tests + evals in one session.
+"""Yorkshire Terrier Unified Session - tests + evals in one session.
 
 Run all (tests + evals):
     protest run examples.yorkshire.session:session

--- a/protest/api.py
+++ b/protest/api.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 from protest.core.collector import Collector
 from protest.core.runner import TestRunner
 from protest.core.suite import (
-    ProTestSuite,  # noqa: TC001 — used at runtime in list_tags
+    ProTestSuite,  # noqa: TC001 - used at runtime in list_tags
 )
 from protest.events.types import Event
 from protest.filters.keyword import KeywordFilterPlugin

--- a/protest/cli/main.py
+++ b/protest/cli/main.py
@@ -140,7 +140,7 @@ def _handle_live_command() -> None:
     )
     args = parser.parse_args(sys.argv[2:])
 
-    from protest.reporting.web import run_live_server  # noqa: PLC0415 — optional dep
+    from protest.reporting.web import run_live_server  # noqa: PLC0415 - optional dep
 
     run_live_server(port=args.port)
 

--- a/protest/console.py
+++ b/protest/console.py
@@ -1,4 +1,4 @@
-"""protest.console — progress output that bypasses test capture.
+"""protest.console - progress output that bypasses test capture.
 
 Usage::
 
@@ -10,10 +10,10 @@ Usage::
             console.print(f"[bold]pipeline:[/] importing {scene.name} ({i+1}/{len(scenes)})")
             await import_scene(scene)
 
-    # Raw mode — no markup processing
+    # Raw mode - no markup processing
     console.print("debug: raw bytes here", raw=True)
 
-    # Section mode — no per-test prefix (use for suite/session-level lines)
+    # Section mode - no per-test prefix (use for suite/session-level lines)
     console.print(f"  Results: {run_dir}", prefix=False)
 
 Messages go through the event bus → reporters display them inline.
@@ -37,7 +37,7 @@ def print(msg: str, *, raw: bool = False, prefix: bool = True) -> None:
 
     Args:
         msg: The message to print. Supports Rich markup unless raw=True.
-        raw: If True, no markup processing — message passed as-is.
+        raw: If True, no markup processing - message passed as-is.
         prefix: If False, omit the per-test indent/bar prefix. Use for
             suite-level or session-level lines (e.g. "Results: <dir>") that
             visually belong outside any single case's output block.
@@ -51,7 +51,7 @@ def print(msg: str, *, raw: bool = False, prefix: bool = True) -> None:
     # so messages appear immediately (not after the test). An earlier public
     # `EventBus.emit_sync` was removed (commit e14ffd5) because its signal-
     # handler use case was async-signal-unsafe, and we don't want to offer
-    # that API to users. Kept private here — the framework itself is the
+    # that API to users. Kept private here - the framework itself is the
     # only caller, and console.print is never invoked from a signal handler.
     for handler_entry in bus._handlers.get(Event.USER_PRINT, []):
         try:
@@ -68,7 +68,7 @@ def print(msg: str, *, raw: bool = False, prefix: bool = True) -> None:
 
 
 def _fallback_print(msg: str, raw: bool) -> None:
-    """Fallback when no event bus — write to real stderr (bypassing capture)."""
+    """Fallback when no event bus - write to real stderr (bypassing capture)."""
     text = msg if raw else strip_markup(msg)
     stream = real_stderr()
     stream.write(text + "\n")

--- a/protest/core/runner.py
+++ b/protest/core/runner.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 from protest.core.collector import Collector
 from protest.core.execution import ParallelExecutor, SuiteManager, TestExecutor
 from protest.core.outcome import OutcomeBuilder
-from protest.core.session import ProTestSession  # noqa: TC001 — used at runtime
+from protest.core.session import ProTestSession  # noqa: TC001 - used at runtime
 from protest.core.tracker import SuiteTracker
 from protest.entities import (
     RunResult,

--- a/protest/core/session.py
+++ b/protest/core/session.py
@@ -371,7 +371,7 @@ class ProTestSession:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> bool:
-        import time  # noqa: PLC0415 — only needed in __aexit__
+        import time  # noqa: PLC0415 - only needed in __aexit__
 
         teardown_start = time.perf_counter()
         set_session_teardown_capture(True)

--- a/protest/di/container.py
+++ b/protest/di/container.py
@@ -741,7 +741,7 @@ class FixtureContainer:
         """Run exit stack teardown, interruptible by cancellation event.
 
         Returns True if cancelled (should abort), False if completed normally.
-        Teardown runs on the SAME event loop as fixture setup — creating a
+        Teardown runs on the SAME event loop as fixture setup - creating a
         new loop would break async resources (drivers, connections) that hold
         references to the original loop.
         """

--- a/protest/di/hints.py
+++ b/protest/di/hints.py
@@ -5,7 +5,7 @@ fails in two scenarios commonly encountered in ProTest user code; this
 module wraps it with a cascade of fallbacks.
 
 ------------------------------------------------------------------------
-Failure mode 1 — names defined in a local scope (PEP 563 stringification)
+Failure mode 1 - names defined in a local scope (PEP 563 stringification)
 ------------------------------------------------------------------------
 
 With ``from __future__ import annotations``, all annotations are stored
@@ -40,7 +40,7 @@ because annotations only reference DI markers (``Use``/``From``) plus
 small, distinctively-named locals.
 
 -------------------------------------------------
-Failure mode 2 — TYPE_CHECKING-only imported types
+Failure mode 2 - TYPE_CHECKING-only imported types
 -------------------------------------------------
 
 Types imported under ``if TYPE_CHECKING:`` are absent at runtime, so
@@ -53,7 +53,7 @@ Types imported under ``if TYPE_CHECKING:`` are absent at runtime, so
     def make() -> HeavyType: ...
 
 Fix: substitute ``Any`` for each unresolvable name and retry. The exact
-type is irrelevant for DI dispatch — only the ``Use(...)``/``From(...)``
+type is irrelevant for DI dispatch - only the ``Use(...)``/``From(...)``
 marker inside ``Annotated[...]`` is consulted at injection time.
 """
 

--- a/protest/entities/core.py
+++ b/protest/entities/core.py
@@ -21,7 +21,7 @@ FixtureCallable: TypeAlias = "Callable[..., Any]"
 
 
 class SuiteKind(str, Enum):
-    """Kind of suite — determines behavior (eval wiring, history, reporting).
+    """Kind of suite - determines behavior (eval wiring, history, reporting).
 
     Inherits from `str` (not `StrEnum`) for Python 3.10 compatibility.
     """

--- a/protest/evals/__init__.py
+++ b/protest/evals/__init__.py
@@ -1,4 +1,4 @@
-"""ProTest evals — native eval support."""
+"""ProTest evals - native eval support."""
 
 from protest.evals.evaluator import (
     EvalCase,

--- a/protest/evals/evaluator.py
+++ b/protest/evals/evaluator.py
@@ -5,8 +5,8 @@ An evaluator is a function decorated with ``@evaluator`` that receives an
 ``Evaluator`` instance that carries identity (for hashing/history) and exposes
 two distinct entry points:
 
-- ``ev(keyword=value, ...)`` — bind params, return a new ``Evaluator``
-- ``ev.run(ctx)`` — execute against an ``EvalContext`` (called by the framework)
+- ``ev(keyword=value, ...)`` - bind params, return a new ``Evaluator``
+- ``ev.run(ctx)`` - execute against an ``EvalContext`` (called by the framework)
 
 Plain callables are not accepted in ``evaluators=[...]``; use ``@evaluator``::
 
@@ -245,8 +245,8 @@ def _validate_return_annotation(fn: Callable[..., Any]) -> None:
 
     The return annotation is the score contract: it determines the score
     names recorded in history and the keys of skipped placeholders
-    (`Evaluator.score_names()`). An unannotated function — or one annotated
-    `-> X | None` / `-> Any` — would make the static derivation diverge
+    (`Evaluator.score_names()`). An unannotated function - or one annotated
+    `-> X | None` / `-> Any` - would make the static derivation diverge
     from what the run actually emits, silently reintroducing unstable
     score keys. Failing at decoration time keeps the contract checkable.
     """
@@ -256,7 +256,7 @@ def _validate_return_annotation(fn: Callable[..., Any]) -> None:
         raise TypeError(
             f"@evaluator '{fn.__name__}': return annotation cannot be resolved "
             f"at runtime ({exc}). Evaluator return types must resolve from "
-            f"module scope — import them at runtime (not only under "
+            f"module scope - import them at runtime (not only under "
             f"TYPE_CHECKING) and define them at module level (a dataclass "
             f"defined inside a function cannot be resolved). The annotation "
             f"drives score names in history and skipped placeholders."
@@ -316,12 +316,12 @@ def extract_scores_from_result(result: Any, evaluator_name: str) -> list[Any]:
 
 
 class Evaluator:
-    """A configured evaluator — callable with identity for hashing.
+    """A configured evaluator - callable with identity for hashing.
 
     Created by the ``@evaluator`` decorator. Two distinct entry points:
 
-    - ``ev(keyword=value, ...)`` — bind params, return a new Evaluator
-    - ``ev.run(ctx)`` — execute against an EvalContext
+    - ``ev(keyword=value, ...)`` - bind params, return a new Evaluator
+    - ``ev.run(ctx)`` - execute against an EvalContext
 
     Splitting these avoids the "callable that does two things based on the
     type of arg[0]" anti-pattern: each method has a single, monomorphic
@@ -390,7 +390,7 @@ def evaluator(fn: Callable[..., Any]) -> Evaluator:
     of dispatching at runtime.
 
     The function must declare a return annotation of ``bool`` or a
-    dataclass — the annotation is the score contract (see
+    dataclass - the annotation is the score contract (see
     `_validate_return_annotation`).
     """
     _validate_return_annotation(fn)

--- a/protest/evals/hashing.py
+++ b/protest/evals/hashing.py
@@ -1,4 +1,4 @@
-"""Content hashing for eval cases — detect when cases or scoring change.
+"""Content hashing for eval cases - detect when cases or scoring change.
 
 Hashes capture identity + configuration, not implementation. A renamed
 parameter changes the hash; a rewritten function body does not. This is
@@ -52,9 +52,9 @@ def _canonical(obj: Any) -> Any:  # noqa: PLR0911
     """Convert an object to a canonical JSON-serializable form.
 
     Resolution order:
-    1. Primitives, list, tuple, dict — native support
-    2. ``evaluator_identity()`` — explicit, user-controlled
-    3. Dataclass / functools.partial / callable — introspection fallback
+    1. Primitives, list, tuple, dict - native support
+    2. ``evaluator_identity()`` - explicit, user-controlled
+    3. Dataclass / functools.partial / callable - introspection fallback
     4. Anything else → CanonicalError
     """
     # --- primitives & containers ---
@@ -74,7 +74,7 @@ def _canonical(obj: Any) -> Any:  # noqa: PLR0911
 
     # --- introspection fallback ---
 
-    # Dataclasses — public fields only (skip _ prefixed runtime internals)
+    # Dataclasses - public fields only (skip _ prefixed runtime internals)
     if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
         return {
             "__type__": type(obj).__qualname__,
@@ -84,14 +84,14 @@ def _canonical(obj: Any) -> Any:  # noqa: PLR0911
                 if not f.name.startswith("_")
             },
         }
-    # functools.partial — qualname + bound kwargs
+    # functools.partial - qualname + bound kwargs
     if isinstance(obj, functools.partial):
         return {
             "fn": _fn_qualname(obj.func),
             "args": _canonical(list(obj.args)) if obj.args else [],
             "kwargs": _canonical(dict(obj.keywords)) if obj.keywords else {},
         }
-    # Plain callable — qualname only
+    # Plain callable - qualname only
     if callable(obj):
         qualname = _fn_qualname(obj)
         if qualname is not None:

--- a/protest/evals/results_writer.py
+++ b/protest/evals/results_writer.py
@@ -1,4 +1,4 @@
-"""EvalResultsWriter — writes per-case eval results as markdown files.
+"""EvalResultsWriter - writes per-case eval results as markdown files.
 
 Listens to TEST_PASS/FAIL events, filters for eval cases, and writes
 a markdown file for each case to .protest/results/<suite>_<timestamp>/.
@@ -92,7 +92,7 @@ def _render_case(case: EvalCaseResult) -> str:
     status = "PASS ✓" if case.passed else "FAIL ✗"
     duration = _format_case_duration(case.duration)
     lines: list[str] = [
-        f"# {case.case_name} — {status} ({duration})",
+        f"# {case.case_name} - {status} ({duration})",
         "",
     ]
 

--- a/protest/evals/suite.py
+++ b/protest/evals/suite.py
@@ -1,4 +1,4 @@
-"""EvalSuite — eval-dedicated suite with judge and model support."""
+"""EvalSuite - eval-dedicated suite with judge and model support."""
 
 from __future__ import annotations
 

--- a/protest/evals/types.py
+++ b/protest/evals/types.py
@@ -17,7 +17,7 @@ class TaskResult(Generic[T]):
     """Optional wrapper for eval task return values with usage stats.
 
     Return this instead of a plain value to report LLM usage for the
-    system under test. ProTest unwraps it transparently — evaluators
+    system under test. ProTest unwraps it transparently - evaluators
     see the plain output.
 
     Usage::
@@ -33,7 +33,7 @@ class TaskResult(Generic[T]):
                 cost=0.003,
             )
 
-        # Or just return str directly — TaskResult is opt-in.
+        # Or just return str directly - TaskResult is opt-in.
     """
 
     output: T
@@ -44,7 +44,7 @@ class TaskResult(Generic[T]):
 
 @dataclass(frozen=True, slots=True)
 class JudgeResponse(Generic[T]):
-    """Return type for Judge.judge() — wraps the output with optional usage stats.
+    """Return type for Judge.judge() - wraps the output with optional usage stats.
 
     Evaluators never see this: ``ctx.judge()`` unwraps and returns ``output``.
     ProTest accumulates tokens/cost for history and display.
@@ -58,7 +58,7 @@ class JudgeResponse(Generic[T]):
             cost=0.003,
         )
 
-        # Or minimal — tokens/cost are optional:
+        # Or minimal - tokens/cost are optional:
         return JudgeResponse(output=result.output)
     """
 
@@ -249,7 +249,7 @@ class ScoreStats:
             # `quantiles(n=20, method='inclusive')` returns 19 cutpoints that
             # split the data into 20 equal groups. Index 0 = 5%, index 18 = 95%.
             # Inclusive method interpolates linearly between adjacent values
-            # and clamps to [min, max] — appropriate for bounded scores.
+            # and clamps to [min, max] - appropriate for bounded scores.
             cuts = statistics.quantiles(sv, n=20, method="inclusive")
             p5_value = cuts[0]
             p95_value = cuts[18]

--- a/protest/evals/wrapper.py
+++ b/protest/evals/wrapper.py
@@ -1,4 +1,4 @@
-"""Eval wrapper — turns a function into a scored eval test.
+"""Eval wrapper - turns a function into a scored eval test.
 
 The wrapper intercepts the return value, runs evaluators, and returns
 an EvalPayload. The rest of the pipeline (executor, outcome builder,
@@ -71,7 +71,7 @@ def make_eval_wrapper(
         per_case = _extract_per_case_evaluators(kwargs)
         all_evaluators.extend(per_case)
 
-        # Duplicate evaluator names are knowable before running anything —
+        # Duplicate evaluator names are knowable before running anything -
         # fail here rather than after burning judge tokens on a doomed case.
         _check_duplicate_evaluator_names(all_evaluators, case_name)
 
@@ -87,7 +87,7 @@ def make_eval_wrapper(
         )
 
         # Defense-in-depth backstop. With per-evaluator namespacing and the
-        # pre-execution name check above, no known path reaches this —
+        # pre-execution name check above, no known path reaches this -
         # distinct evaluator names can't emit the same key. Kept because
         # EvalPayload.scores is a dict: if a future extraction path ever
         # produces duplicate keys, silent overwrite is the worst failure.
@@ -162,7 +162,7 @@ def _validate_single_evalcase_param(func: Any) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Extract helpers — pull EvalCase from kwargs
+# Extract helpers - pull EvalCase from kwargs
 # ---------------------------------------------------------------------------
 
 
@@ -173,8 +173,8 @@ def _check_duplicate_evaluator_names(
 
     Score names are namespaced per evaluator, so a duplicate evaluator name
     (the same @evaluator attached twice, possibly rebound with different
-    kwargs) guarantees colliding score keys. Runs before any evaluator —
-    including judge calls — executes.
+    kwargs) guarantees colliding score keys. Runs before any evaluator -
+    including judge calls - executes.
     """
     seen: set[str] = set()
     duplicates: list[str] = []
@@ -260,7 +260,7 @@ async def run_evaluators(
 
     Callers must have validated the list (Evaluator | ShortCircuit only) at the
     boundary; the loop below trusts the Union and uses isinstance solely to
-    narrow it — the only legitimate isinstance kept in this module.
+    narrow it - the only legitimate isinstance kept in this module.
     """
     ctx = EvalContext(
         name=case_name,

--- a/protest/exceptions.py
+++ b/protest/exceptions.py
@@ -108,7 +108,7 @@ class MultipleEvalCaseParamsError(ProTestError):
         params = ", ".join(param_names)
         super().__init__(
             f"Eval '{func_name}' declares multiple EvalCase parameters: {params}. "
-            f"Only one EvalCase parameter is supported per eval — it is used "
+            f"Only one EvalCase parameter is supported per eval - it is used "
             f"for case identity (name), expected output, inputs, metadata, "
             f"and per-case evaluators. Merge the cases into a single EvalCase, "
             f"or split into separate evals."
@@ -122,7 +122,7 @@ class ScoreNameCollisionError(ProTestError):
     dataclass results, the evaluator's name for bool results), so distinct
     evaluators can freely share field names like `ok` or `detail`. A
     collision therefore means the same evaluator name appears twice on one
-    case — e.g. the same `@evaluator` function attached twice (possibly with
+    case - e.g. the same `@evaluator` function attached twice (possibly with
     different bound kwargs), or two functions sharing a `__name__`. The
     duplicate scores would silently overwrite each other in the per-case
     report and history, so we fail loud instead.
@@ -133,7 +133,7 @@ class ScoreNameCollisionError(ProTestError):
         super().__init__(
             f"Score-name collision in eval '{case_name}': {dup_str}. "
             f"Scores are namespaced per evaluator, so this means the same "
-            f"evaluator name appears more than once on this case — the same "
+            f"evaluator name appears more than once on this case - the same "
             f"@evaluator attached twice (e.g. with different bound kwargs) "
             f"or two functions sharing a name. Wrap each binding in its own "
             f"named @evaluator function so every score name is unique."

--- a/protest/filters/kind.py
+++ b/protest/filters/kind.py
@@ -1,4 +1,4 @@
-"""KindFilterPlugin — filters tests by suite kind (test/eval)."""
+"""KindFilterPlugin - filters tests by suite kind (test/eval)."""
 
 from __future__ import annotations
 

--- a/protest/history/__init__.py
+++ b/protest/history/__init__.py
@@ -1,4 +1,4 @@
-"""History module — run tracking for tests and evals."""
+"""History module - run tracking for tests and evals."""
 
 from protest.history.storage import (
     HISTORY_FILE,

--- a/protest/history/collector.py
+++ b/protest/history/collector.py
@@ -73,7 +73,7 @@ def _git(*args: str) -> str:
 
 def _get_pkg_version(name: str) -> str | None:
     try:
-        from importlib.metadata import version  # noqa: PLC0415 — inside try/except
+        from importlib.metadata import version  # noqa: PLC0415 - inside try/except
 
         return version(name)
     except Exception:

--- a/protest/history/plugin.py
+++ b/protest/history/plugin.py
@@ -1,4 +1,4 @@
-"""HistoryPlugin — persists test and eval run results as JSONL."""
+"""HistoryPlugin - persists test and eval run results as JSONL."""
 
 from __future__ import annotations
 
@@ -214,7 +214,7 @@ def _serialize_eval_case(case: EvalCaseResult) -> dict[str, Any]:
     """Serialize an eval case result for JSONL storage.
 
     Skipped scores are excluded: a ShortCircuit skip produces
-    `EvalScore(value=False, skipped=True)` — serializing it as an assertion
+    `EvalScore(value=False, skipped=True)` - serializing it as an assertion
     would look like a real failure in `history --compare` diffs.
 
     `case.duration` here is `EvalPayload.task_duration` (SUT-only timing,

--- a/protest/history/storage.py
+++ b/protest/history/storage.py
@@ -61,7 +61,7 @@ HISTORY_FILE = "history.jsonl"
 # JSONL entry schema version. Bump when the on-disk shape changes in a way
 # that older readers can't transparently handle (new required fields,
 # restructured nesting). Entries written before this was introduced have no
-# `schema_version` key and are treated as version 0 (legacy — best-effort).
+# `schema_version` key and are treated as version 0 (legacy - best-effort).
 SCHEMA_VERSION = 1
 
 _warned_future_versions: set[int] = set()

--- a/protest/plugin.py
+++ b/protest/plugin.py
@@ -144,7 +144,7 @@ class PluginBase:
         """Suite ends (after fixture teardown)."""
 
     def on_eval_suite_end(self, report: Any) -> None | Awaitable[None]:
-        """Eval suite finished — aggregated report with scores/stats."""
+        """Eval suite finished - aggregated report with scores/stats."""
 
     def on_user_print(self, data: Any) -> None | Awaitable[None]:
         """User-initiated print via protest.console.print()."""

--- a/protest/reporting/ascii.py
+++ b/protest/reporting/ascii.py
@@ -59,9 +59,9 @@ def _format_test_name(result: TestResult, include_suite: bool = False) -> str:
 
 
 def _format_eval_scores_inline(result: TestResult, short: bool = False) -> str:
-    """Format eval scores for inline display — ASCII version (no glyphs).
+    """Format eval scores for inline display - ASCII version (no glyphs).
 
-    When `short=True`, only failing/skipped scores are shown — passing scores
+    When `short=True`, only failing/skipped scores are shown - passing scores
     are hidden to keep the output readable on large suites.
     """
     if not result.eval_payload:
@@ -108,7 +108,7 @@ class AsciiReporter(PluginBase):
     def activate(cls, ctx: PluginContext) -> Self | None:
         # Activate when --no-color was passed, OR when `rich` is not
         # installed (RichReporter would otherwise leave the run silent).
-        import importlib.util  # noqa: PLC0415 — std lib, kept local for clarity
+        import importlib.util  # noqa: PLC0415 - std lib, kept local for clarity
 
         if ctx.get("no_color", False) or importlib.util.find_spec("rich") is None:
             return cls(

--- a/protest/reporting/rich_reporter.py
+++ b/protest/reporting/rich_reporter.py
@@ -43,7 +43,7 @@ def _rich_available() -> bool:
 
 
 # Per-run pass-rate thresholds for the eval suite color cue.
-# Strict default — green only if every case passes; yellow above half.
+# Strict default - green only if every case passes; yellow above half.
 _PERFECT_PASS_RATE = 1.0
 _PARTIAL_PASS_RATE = 0.5
 
@@ -64,7 +64,7 @@ def _format_test_name(result: TestResult) -> str:
 def _format_eval_scores_inline(result: TestResult, short: bool = False) -> str:
     """Format eval scores for inline display (e.g. ' bg_score=0.8 char_id=1.0').
 
-    When `short=True`, only failing/skipped scores are shown — passing scores
+    When `short=True`, only failing/skipped scores are shown - passing scores
     are hidden to keep the output readable on large suites.
     """
     if not result.eval_payload:
@@ -99,7 +99,7 @@ class RichReporter(PluginBase):
         show_output: bool = False,
         short: bool = False,
     ) -> None:
-        from rich.console import Console  # noqa: PLC0415 — optional dep, lazy
+        from rich.console import Console  # noqa: PLC0415 - optional dep, lazy
 
         self.console = Console(highlight=False)
         self._verbosity = verbosity
@@ -179,7 +179,7 @@ class RichReporter(PluginBase):
 
     def _print_bypass(self, message: str) -> None:
         """Print bypassing capture (for lifecycle messages emitted during tests)."""
-        from rich.console import Console  # noqa: PLC0415 — optional dep, lazy
+        from rich.console import Console  # noqa: PLC0415 - optional dep, lazy
 
         stream = real_stdout()
         Console(file=stream, highlight=False).print(message)
@@ -408,7 +408,7 @@ class RichReporter(PluginBase):
                 self._print(f"[dim]{escaped_line}[/]")
 
     def on_user_print(self, data: Any) -> None:
-        from rich.console import Console  # noqa: PLC0415 — optional dep, lazy
+        from rich.console import Console  # noqa: PLC0415 - optional dep, lazy
 
         msg, raw, prefix = data
         # Write to the real stdout, bypassing capture
@@ -424,7 +424,7 @@ class RichReporter(PluginBase):
     def on_eval_suite_end(self, report: Any) -> None:
         if not isinstance(report, EvalSuiteReport):
             return
-        from rich.table import Table  # noqa: PLC0415 — optional dep, lazy
+        from rich.table import Table  # noqa: PLC0415 - optional dep, lazy
 
         stats = report.all_score_stats()
         self._print("")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def _isolate_protest_history(tmp_path: "Path", monkeypatch: pytest.MonkeyPatch) 
 
     Tests that forget to pass `history_dir=tmp_path` would otherwise write
     into the repo's real `.protest/history.jsonl`. The monkeypatch targets
-    the single source of truth (`storage.DEFAULT_HISTORY_DIR`) — all
+    the single source of truth (`storage.DEFAULT_HISTORY_DIR`) - all
     consumers access it via the module so the override is seen everywhere.
 
     Tests that pass an explicit `history_dir` still use that value, because

--- a/tests/di/test_pep563_annotations.py
+++ b/tests/di/test_pep563_annotations.py
@@ -31,7 +31,7 @@ def module_level_fixture_that_raises() -> str:
     raise RuntimeError("Fixture error")
 
 
-# Module-level ForEach — mirrors real usage where ForEach is defined at module scope
+# Module-level ForEach - mirrors real usage where ForEach is defined at module scope
 module_numbers = ForEach([10, 20, 30])
 module_numbers_short = ForEach([1, 2])
 

--- a/tests/evals/test_duration_precision.py
+++ b/tests/evals/test_duration_precision.py
@@ -1,10 +1,10 @@
-"""Tests for C3 — sub-millisecond duration handling.
+"""Tests for C3 - sub-millisecond duration handling.
 
 The eval pipeline persists `EvalPayload.task_duration` (SUT-only timing).
 For deterministic stubs / fast classifiers, that value is sub-millisecond
 and the previous serializer (`round(_, 3)`) collapsed everything to `0.0`,
 making run-over-run comparisons useless. The markdown renderer had the
-matching bug — it printed `0ms` for any sub-ms task.
+matching bug - it printed `0ms` for any sub-ms task.
 """
 
 from __future__ import annotations
@@ -37,7 +37,7 @@ class TestSerializerPrecision:
         case = _make_case(2.07e-05)  # 20.7 µs
         entry = _serialize_eval_case(case)
         # Previously: 0.0 (round to 3 decimals)
-        # Now: 2e-05 (round to 5 decimals — 10 µs precision)
+        # Now: 2e-05 (round to 5 decimals - 10 µs precision)
         assert entry["duration"] > 0
         assert entry["duration"] == 2e-05
 
@@ -59,7 +59,7 @@ class TestMarkdownDurationFormat:
         assert _format_case_duration(2.07e-05) == "21µs"
 
     def test_two_decimals_in_low_milliseconds(self) -> None:
-        # 2.5 ms — keep one fractional digit so 1ms vs 2ms is visible.
+        # 2.5 ms - keep one fractional digit so 1ms vs 2ms is visible.
         assert _format_case_duration(0.0025) == "2.50ms"
 
     def test_integer_milliseconds_in_mid_range(self) -> None:

--- a/tests/evals/test_e2e.py
+++ b/tests/evals/test_e2e.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import subprocess
 from dataclasses import dataclass
-from pathlib import Path  # noqa: TC003 — used at runtime (pytest tmp_path)
+from pathlib import Path  # noqa: TC003 - used at runtime (pytest tmp_path)
 from typing import Annotated, Any
 
 import pytest
@@ -49,7 +49,7 @@ from protest.evals.evaluators import (
 from protest.evals.hashing import compute_case_hash, compute_eval_hash
 from protest.evals.results_writer import EvalResultsWriter
 from protest.evals.suite import EvalSuite
-from protest.evals.types import EvalSuiteReport  # noqa: TC001 — used at runtime
+from protest.evals.types import EvalSuiteReport  # noqa: TC001 - used at runtime
 from protest.filters.kind import KindFilterPlugin
 from protest.history.storage import append_entry, clean_dirty
 from protest.plugin import PluginBase, PluginContext
@@ -76,7 +76,7 @@ def fake_accuracy(ctx: EvalContext) -> FakeAccuracyResult:
 
 @evaluator
 async def async_fake_accuracy(ctx: EvalContext) -> FakeAccuracyResult:
-    """Async evaluator — simulates LLMJudge which calls an async LLM API."""
+    """Async evaluator - simulates LLMJudge which calls an async LLM API."""
     # Simulate async I/O (e.g. LLM call) without actually blocking
     if ctx.expected_output and ctx.expected_output.lower() in ctx.output.lower():
         return FakeAccuracyResult(accuracy=1.0, matches_expected=True)
@@ -734,7 +734,7 @@ class TestBuiltinEvaluators:
         """Regression: `min_recall=0.0` must always pass (no discontinuity at 0).
 
         Earlier behavior: `min_recall=0.0` flipped to strict mode (all required),
-        while `min_recall=0.0001` was permissive — surprising at the boundary.
+        while `min_recall=0.0001` was permissive - surprising at the boundary.
         Now `recall >= min_recall` applies uniformly.
         """
         e = contains_keywords(keywords=["alpha", "beta"], min_recall=0.0)
@@ -775,7 +775,7 @@ class TestBuiltinEvaluators:
         """Sized containers: empty -> False, non-empty -> True.
 
         Earlier behavior fell through to `return True` for any non-string,
-        so `not_empty([])` reported True — misleading for tasks that return
+        so `not_empty([])` reported True - misleading for tasks that return
         lists/dicts (e.g. tool calls, retrieved chunks).
         """
         # Helper accepts Any at runtime; type hint is just a default.
@@ -806,7 +806,7 @@ class TestBuiltinEvaluators:
         assert not_empty.run(ctx_int) is True
 
         ctx_zero: Any = self._make_ctx("")
-        ctx_zero.output = 0  # 0 is not None, not Sized — still passes.
+        ctx_zero.output = 0  # 0 is not None, not Sized - still passes.
         assert not_empty.run(ctx_zero) is True
 
     def test_max_length(self) -> None:
@@ -922,7 +922,7 @@ class TestScoringV2:
         assert result.success is True
 
     def test_float_return_annotation_raises_at_decoration(self) -> None:
-        """`-> float` is rejected by @evaluator itself — the return annotation
+        """`-> float` is rejected by @evaluator itself - the return annotation
         is the score contract and must be bool or a dataclass."""
         with pytest.raises(TypeError, match="bool or a dataclass"):
 
@@ -945,7 +945,7 @@ class TestScoringV2:
                 return None
 
     def test_unresolvable_return_annotation_raises_at_decoration(self) -> None:
-        """A function-local dataclass can't be resolved by get_type_hints —
+        """A function-local dataclass can't be resolved by get_type_hints -
         the placeholder keys would silently diverge from the real run."""
 
         @dataclass

--- a/tests/evals/test_eval_case_result.py
+++ b/tests/evals/test_eval_case_result.py
@@ -110,7 +110,7 @@ class TestFromTestResultHappyPath:
 
 
 class TestFromTestResultPassedDerivation:
-    """`passed` is derived, not passed in — the writer no longer gets it wrong."""
+    """`passed` is derived, not passed in - the writer no longer gets it wrong."""
 
     def test_passed_when_no_error_and_payload_passed(self) -> None:
         result = _make_result(payload=_make_payload(passed=True))

--- a/tests/evals/test_hashing.py
+++ b/tests/evals/test_hashing.py
@@ -1,4 +1,4 @@
-"""Tests for protest.evals.hashing — fail-hard canonicalization."""
+"""Tests for protest.evals.hashing - fail-hard canonicalization."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from protest.evals.hashing import (
 )
 
 # ---------------------------------------------------------------------------
-# Fixtures — representative evaluator types
+# Fixtures - representative evaluator types
 # ---------------------------------------------------------------------------
 
 
@@ -49,7 +49,7 @@ def parameterized_function(ctx: object, keywords: list[str]) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# _canonical — primitives & containers
+# _canonical - primitives & containers
 # ---------------------------------------------------------------------------
 
 
@@ -69,7 +69,7 @@ class TestCanonicalPrimitives:
 
 
 # ---------------------------------------------------------------------------
-# _canonical — dataclass handling
+# _canonical - dataclass handling
 # ---------------------------------------------------------------------------
 
 
@@ -99,7 +99,7 @@ class TestCanonicalDataclass:
     def test_dataclass_with_lock_skips_private_fields(self) -> None:
         """Regression: dataclasses.asdict() deepcopy fails on threading.Lock.
 
-        Private fields (_prefixed) are runtime internals, not config — excluded from hash.
+        Private fields (_prefixed) are runtime internals, not config - excluded from hash.
         """
         ev = LockHoldingEvaluator(name="llm_judge")
         result = _canonical(ev)
@@ -108,7 +108,7 @@ class TestCanonicalDataclass:
 
 
 # ---------------------------------------------------------------------------
-# _canonical — callables (the real-world evaluator path)
+# _canonical - callables (the real-world evaluator path)
 # ---------------------------------------------------------------------------
 
 
@@ -138,7 +138,7 @@ class TestCanonicalCallable:
 
 
 # ---------------------------------------------------------------------------
-# _canonical — evaluator_identity (explicit, user-controlled)
+# _canonical - evaluator_identity (explicit, user-controlled)
 # ---------------------------------------------------------------------------
 
 
@@ -198,7 +198,7 @@ class TestCanonicalEvaluatorIdentity:
 
 
 # ---------------------------------------------------------------------------
-# _canonical — fail-hard on unknown types
+# _canonical - fail-hard on unknown types
 # ---------------------------------------------------------------------------
 
 

--- a/tests/evals/test_judge.py
+++ b/tests/evals/test_judge.py
@@ -50,7 +50,7 @@ class FakeJudge:
         if output_type is str:
             return JudgeResponse(output=f"judged: {prompt[:20]}")
         # Dataclass fallback: caller must use a dataclass whose fields all
-        # have defaults — no real LLM call to derive values from.
+        # have defaults - no real LLM call to derive values from.
         return JudgeResponse(output=output_type())
 
 
@@ -359,7 +359,7 @@ class TestJudgeE2E:
 
 class TestTaskResult:
     def test_task_result_unwrapped_for_evaluators(self) -> None:
-        """TaskResult is unwrapped — evaluators see the plain output."""
+        """TaskResult is unwrapped - evaluators see the plain output."""
 
         @evaluator
         def check_output(ctx: EvalContext) -> bool:

--- a/tests/evals/test_multiple_evalcase_params.py
+++ b/tests/evals/test_multiple_evalcase_params.py
@@ -1,4 +1,4 @@
-"""Tests for `_validate_single_evalcase_param` — D1 registration-time check.
+"""Tests for `_validate_single_evalcase_param` - D1 registration-time check.
 
 The runtime contract (`_find_case`) picks the first `EvalCase` in kwargs and
 silently drops any others. The wrapper detects > 1 EvalCase param at

--- a/tests/evals/test_score_name_collision.py
+++ b/tests/evals/test_score_name_collision.py
@@ -2,7 +2,7 @@
 
 Dataclass scores are namespaced per evaluator (``<evaluator>.<field>``),
 so two evaluators on the same case can both declare plain ``ok`` /
-``detail`` fields. A collision is still possible — and raises — when the
+``detail`` fields. A collision is still possible - and raises - when the
 same evaluator name appears twice on one case (the same ``@evaluator``
 attached twice, e.g. rebound with different kwargs).
 """
@@ -39,7 +39,7 @@ class _ShapeA:
 @dataclass
 class _ShapeB:
     other_check: Annotated[bool, Verdict]
-    detail: Annotated[str, Reason] = ""  # same field name as _ShapeA — fine
+    detail: Annotated[str, Reason] = ""  # same field name as _ShapeA - fine
 
 
 @evaluator
@@ -59,7 +59,7 @@ def _bool_one(ctx: EvalContext) -> bool:
 
 @dataclass
 class _ShapeWithBoolOneField:
-    _bool_one: Annotated[bool, Verdict]  # namespaced — no clash with _bool_one
+    _bool_one: Annotated[bool, Verdict]  # namespaced - no clash with _bool_one
 
 
 @evaluator
@@ -138,7 +138,7 @@ class TestCollisionRaises:
         assert "c3" in msg
 
     def test_collision_detected_before_any_evaluator_runs(self) -> None:
-        """The name check fires pre-execution — no evaluator (judge) call is made."""
+        """The name check fires pre-execution - no evaluator (judge) call is made."""
         calls: list[str] = []
 
         @evaluator
@@ -184,7 +184,7 @@ class TestSkippedPlaceholderNamespacing:
         assert "_shape_a.matches" in payload.scores
         assert "_shape_a.detail" in payload.scores
         assert payload.scores["_shape_a.matches"].skipped is True
-        # Bare evaluator name must NOT appear — that was the pre-namespacing key.
+        # Bare evaluator name must NOT appear - that was the pre-namespacing key.
         assert "_shape_a" not in payload.scores
 
     def test_skipped_bool_evaluator_keeps_bare_name(self) -> None:
@@ -207,7 +207,7 @@ class TestSkippedPlaceholderNamespacing:
 class TestSessionPath:
     def test_session_with_shared_field_names_runs_clean(self) -> None:
         """Smoke check: shared `detail` fields pass through the full session."""
-        from protest.api import run_session  # noqa: PLC0415 — heavy import
+        from protest.api import run_session  # noqa: PLC0415 - heavy import
 
         session = ProTestSession()
         suite = EvalSuite("evals")

--- a/tests/evals/test_score_stats.py
+++ b/tests/evals/test_score_stats.py
@@ -1,4 +1,4 @@
-"""Tests for `ScoreStats.from_values` — percentile correctness.
+"""Tests for `ScoreStats.from_values` - percentile correctness.
 
 Pre-M11, p5/p95 used `int(n * 0.05)` index lookup, which collapses to
 min/max for small samples (the typical eval case). Post-M11 uses

--- a/tests/history/test_append_entry_concurrency.py
+++ b/tests/history/test_append_entry_concurrency.py
@@ -1,4 +1,4 @@
-"""Tests for `append_entry` — concurrent writer safety.
+"""Tests for `append_entry` - concurrent writer safety.
 
 Covers the basic invariant (one entry = one parseable line) and the
 multiprocess-concurrency case: N workers append concurrently to the same
@@ -33,7 +33,7 @@ def _worker_append(args: tuple[str, int, int]) -> None:
 
 
 def _worker_append_innocent(args: tuple[str, int, int]) -> None:
-    """Append entries on an unrelated commit — `clean_dirty` must not touch them."""
+    """Append entries on an unrelated commit - `clean_dirty` must not touch them."""
     path_str, worker_id, count = args
     path = Path(path_str)
     for i in range(count):
@@ -105,7 +105,7 @@ class TestAppendEntryConcurrency:
 
         lines = path.read_text().splitlines()
         assert len(lines) == total, (
-            f"expected {total} lines, got {len(lines)} — some writes were lost"
+            f"expected {total} lines, got {len(lines)} - some writes were lost"
         )
 
         counts_per_worker: dict[int, int] = {}
@@ -123,13 +123,13 @@ class TestCleanDirtyConcurrency:
 
     The dangerous race: clean_dirty does (read → compute kept → truncate →
     rewrite). Without a lock, an `append_entry` landing between the read
-    and the truncate is silently overwritten — the new entry disappears.
+    and the truncate is silently overwritten - the new entry disappears.
     Here we run both in parallel and check the conserved quantity: every
     appended "innocent" entry (different commit) must survive.
     """
 
     def test_concurrent_append_not_dropped_by_clean_dirty(self, tmp_path: Path) -> None:
-        # Skip outside a git repo — clean_dirty depends on `git rev-parse HEAD`.
+        # Skip outside a git repo - clean_dirty depends on `git rev-parse HEAD`.
         try:
             subprocess.run(
                 ["git", "rev-parse", "HEAD"],  # noqa: S607
@@ -170,10 +170,10 @@ class TestCleanDirtyConcurrency:
             entry = json.loads(raw)
             if entry.get("git", {}).get("commit") == "innocent_commit":
                 innocent_count += 1
-        # All `per_worker` innocent appends survived — none silently
+        # All `per_worker` innocent appends survived - none silently
         # discarded by an interleaved clean_dirty truncate.
         assert innocent_count == per_worker, (
-            f"expected {per_worker} innocent entries, got {innocent_count} — "
+            f"expected {per_worker} innocent entries, got {innocent_count} - "
             "concurrent clean_dirty dropped some appends"
         )
 

--- a/tests/history/test_history_dir_isolation.py
+++ b/tests/history/test_history_dir_isolation.py
@@ -3,7 +3,7 @@
 The autouse `_isolate_protest_history` fixture in `tests/conftest.py`
 monkeypatches `storage.DEFAULT_HISTORY_DIR` to a per-test temp directory.
 These tests assert that both the storage functions and the HistoryPlugin
-pick up the override — any regression in the plumbing would let runs leak
+pick up the override - any regression in the plumbing would let runs leak
 into `.protest/history.jsonl` in the real project cwd.
 """
 

--- a/tests/history/test_schema_version.py
+++ b/tests/history/test_schema_version.py
@@ -4,7 +4,7 @@ The plugin stamps every new entry with `schema_version`. Readers skip
 entries with a future version (written by a newer protest) and warn once
 per version.
 
-Legacy entries (no `schema_version` key at all — written before this was
+Legacy entries (no `schema_version` key at all - written before this was
 introduced) are treated as version 0 and read without warning.
 """
 
@@ -91,7 +91,7 @@ class TestFutureVersionSkipped:
 
 
 class TestLegacyEntriesStillReadable:
-    """Pre-schema_version entries have no key — treat as legacy (version 0)."""
+    """Pre-schema_version entries have no key - treat as legacy (version 0)."""
 
     def test_entry_without_schema_version_is_read(self, tmp_path: Path) -> None:
         path = tmp_path / ".protest" / storage.HISTORY_FILE

--- a/tests/reporting/test_reporter_symmetry.py
+++ b/tests/reporting/test_reporter_symmetry.py
@@ -2,14 +2,14 @@
 
 Goal: catch divergences between the two reporters before they ship as silent
 asymmetries. A user who swaps `--no-color` should get the same *semantic*
-output (same fields, same filters) — only the visual style differs.
+output (same fields, same filters) - only the visual style differs.
 
 Three axes are enforced:
 
-1. Structural  — both reporters expose the same public hooks (`on_*` handlers).
-2. CLI         — both reporters react to the same shared flags (`--show-output`,
+1. Structural  - both reporters expose the same public hooks (`on_*` handlers).
+2. CLI         - both reporters react to the same shared flags (`--show-output`,
                  `--show-logs`). Reporter-specific flags (`--no-color`) are allowed.
-3. Behavioral  — parametrized scenarios drive the same input through both
+3. Behavioral  - parametrized scenarios drive the same input through both
                  reporters and assert the same *semantic* markers appear
                  (score names for eval pass, eval detail on fail, summary omits
                  eval failures, etc.).
@@ -161,7 +161,7 @@ class TestStructuralSymmetry:
         """Both reporters override the same set of on_* methods.
 
         If one reporter starts overriding a hook that the other ignores, an
-        event will be invisible in the "other" reporter — that's the bug we
+        event will be invisible in the "other" reporter - that's the bug we
         want to catch at test time, not in production.
         """
         rich_handlers = _public_handlers(RichReporter)
@@ -186,7 +186,7 @@ class TestCliSymmetry:
     """Ensure the two reporters consume the same shared flags.
 
     Reporter-specific flags are allowed (e.g. `--no-color` makes sense only on
-    the Ascii side) — they're expected to appear in either one but not both.
+    the Ascii side) - they're expected to appear in either one but not both.
     The rule is: anything in `_SHARED_CLI_FLAGS` must be *activatable* on both
     reporters (read from PluginContext via activate()).
     """
@@ -220,7 +220,7 @@ class TestCliSymmetry:
             redeclared = dests & _SHARED_CLI_FLAGS
             assert not redeclared, (
                 f"{cls.__name__}.add_cli_options redeclares shared flags: "
-                f"{sorted(redeclared)} — move them to cli._create_run_parser"
+                f"{sorted(redeclared)} - move them to cli._create_run_parser"
             )
 
 
@@ -262,7 +262,7 @@ class TestBehavioralSymmetry:
     ) -> None:
         """Given a failing eval, both reporters dump inputs/output/expected.
 
-        This must happen regardless of --show-output — the user can't debug
+        This must happen regardless of --show-output - the user can't debug
         a failed assertion without seeing what the task actually produced.
         """
         reporter = _make_reporter(reporter_cls)
@@ -314,7 +314,7 @@ class TestBehavioralSymmetry:
         """End-of-session summary must not re-list eval failures.
 
         Eval cases are already displayed inline via on_test_fail. Re-listing
-        them in the summary duplicates noise — the pattern agreed on is
+        them in the summary duplicates noise - the pattern agreed on is
         "non_eval_failures only".
         """
         reporter = _make_reporter(reporter_cls)

--- a/tests/test_console_print.py
+++ b/tests/test_console_print.py
@@ -1,4 +1,4 @@
-"""Tests for `protest.console.print` — payload shape and reporter formatting.
+"""Tests for `protest.console.print` - payload shape and reporter formatting.
 
 `console.print(msg, raw=False, prefix=True)` builds a 3-tuple payload
 `(msg, raw, prefix)` dispatched on USER_PRINT. Each reporter unpacks the
@@ -51,7 +51,7 @@ class TestAsciiReporterUserPrint:
     def test_prefix_false_no_bar(self, stdout_buffer: io.StringIO) -> None:
         reporter = AsciiReporter()
         reporter.on_user_print(("Results: /tmp/foo", False, False))
-        # No bar — visually a section line, not attached to a case.
+        # No bar - visually a section line, not attached to a case.
         assert stdout_buffer.getvalue() == "Results: /tmp/foo\n"
 
 
@@ -111,7 +111,7 @@ class TestConsolePrintHandlerErrors:
 
     Earlier behavior: `contextlib.suppress(Exception)` swallowed any handler
     raise. A reporter bug (e.g. malformed Rich markup) made `console.print`
-    silently no-op — users assumed the call did nothing.
+    silently no-op - users assumed the call did nothing.
     """
 
     def _bus_with_failing_handler(
@@ -152,7 +152,7 @@ class TestConsolePrintHandlerErrors:
         monkeypatch.setattr("protest.console.real_stderr", raising_stderr)
         self._bus_with_failing_handler(monkeypatch, RuntimeError("boom"))
 
-        # Must not raise — the outer suppress() is the last line of defense.
+        # Must not raise - the outer suppress() is the last line of defense.
         console.print("anything")
 
     def test_successful_handler_does_not_touch_stderr(


### PR DESCRIPTION
Mechanical sweep of all 205 em dashes (`—`) in tracked files: comments, docstrings, error messages, and docs now use plain hyphens. No functional change.

Verified: zero em dashes remain in tracked files, no binary touched, full suite (1234) green, lint and mypy clean.