### PR TITLE
evals: reject dataclass evaluator returns with no scored fields

### DIFF
--- a/docs/evals.md
+++ b/docs/evals.md
@@ -194,10 +194,13 @@ Unannotated fields are ignored by the runner - free metadata.
 
 The return annotation is **required** and must be `bool` or a dataclass -
 `@evaluator` raises `TypeError` at decoration time otherwise (missing
-annotation, `-> float`, `-> X | None`, …). The annotation is the score
-contract: it determines the score names recorded in history and the keys
-of skipped placeholders, so it must also resolve at runtime - import the
-return type for real (not only under `TYPE_CHECKING`) and define it at
+annotation, `-> float`, `-> X | None`, …). A dataclass return must carry
+at least one `Metric`/`Verdict`/`Reason` field: one with only unannotated
+fields emits no scores, and a case whose evaluators all emit none passes
+vacuously, so it is rejected at decoration time too. The annotation is the
+score contract: it determines the score names recorded in history and the
+keys of skipped placeholders, so it must also resolve at runtime - import
+the return type for real (not only under `TYPE_CHECKING`) and define it at
 module level.
 
 ### Tracking-Only Evaluators

--- a/protest/evals/evaluator.py
+++ b/protest/evals/evaluator.py
@@ -255,6 +255,12 @@ def _validate_return_annotation(fn: Callable[..., Any]) -> None:
     `-> X | None` / `-> Any` - would make the static derivation diverge
     from what the run actually emits, silently reintroducing unstable
     score keys. Failing at decoration time keeps the contract checkable.
+
+    A dataclass return must also carry at least one Metric/Verdict/Reason
+    field. Without one it emits zero scores, and a case whose evaluators all
+    emit zero scores passes vacuously (`all([])` is True) - the same
+    silent pass the NoEvaluatorsError guard exists to prevent, slipping
+    through because that guard counts evaluators, not scores.
     """
     try:
         hints = get_type_hints(fn)
@@ -269,7 +275,18 @@ def _validate_return_annotation(fn: Callable[..., Any]) -> None:
         ) from exc
     ret = hints.get("return")
     base = get_origin(ret) or ret
-    if ret is bool or (isinstance(base, type) and dataclasses.is_dataclass(base)):
+    if ret is bool:
+        return
+    if isinstance(base, type) and dataclasses.is_dataclass(base):
+        if not _annotated_score_field_names(base):
+            raise TypeError(
+                f"@evaluator '{fn.__name__}' returns dataclass "
+                f"'{base.__name__}' with no Metric/Verdict/Reason-annotated "
+                f"fields, so it emits zero scores. A case whose evaluators all "
+                f"emit zero scores passes vacuously (all([]) is True), hiding "
+                f"the result the same way zero evaluators would. Annotate at "
+                f"least one field with Metric, Verdict, or Reason."
+            )
         return
     raise TypeError(
         f"@evaluator '{fn.__name__}' must declare a return annotation of bool "

--- a/tests/evals/test_evaluator_validation.py
+++ b/tests/evals/test_evaluator_validation.py
@@ -8,12 +8,18 @@ downstream code work on a uniform ``Evaluator | ShortCircuit`` Union.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Annotated
+
 import pytest
 
 from protest.evals.evaluator import (
     EvalCase,
     EvalContext,
+    Metric,
+    Reason,
     ShortCircuit,
+    Verdict,
     evaluator,
     validate_evaluators,
 )
@@ -26,6 +32,34 @@ def _ok(ctx: EvalContext) -> bool:
 
 def _plain_callable(ctx: EvalContext) -> bool:
     return True
+
+
+# Module-level dataclasses so get_type_hints can resolve the return annotation.
+@dataclass
+class _NoAnnotatedFields:
+    note: str
+    count: int
+
+
+@dataclass
+class _MetricOnly:
+    overlap: Annotated[float, Metric]
+
+
+@dataclass
+class _VerdictOnly:
+    ok: Annotated[bool, Verdict]
+
+
+@dataclass
+class _ReasonOnly:
+    why: Annotated[str, Reason]
+
+
+@dataclass
+class _AnnotatedPlusMetadata:
+    ok: Annotated[bool, Verdict]
+    debug: dict  # unannotated free metadata, ignored by the runner
 
 
 class TestValidateEvaluators:
@@ -55,3 +89,48 @@ class TestEvalCaseValidates:
 
     def test_evalcase_accepts_evaluator(self) -> None:
         EvalCase(inputs="x", name="c", evaluators=[_ok])
+
+
+class TestDataclassReturnMustHaveAnnotatedField:
+    """A dataclass return with zero Metric/Verdict/Reason fields emits no
+    scores, so a case relying only on it passes vacuously - the silent pass
+    that survives the NoEvaluatorsError guard (that guard counts evaluators,
+    not scores). Reject it at decoration time.
+    """
+
+    def test_zero_annotated_fields_raises(self) -> None:
+        with pytest.raises(TypeError, match="no Metric/Verdict/Reason"):
+
+            @evaluator
+            def empty(ctx: EvalContext) -> _NoAnnotatedFields:
+                return _NoAnnotatedFields(note="x", count=1)
+
+    def test_metric_only_accepted(self) -> None:
+        """Tracking-only evaluators (e.g. word_overlap) stay valid."""
+
+        @evaluator
+        def tracker(ctx: EvalContext) -> _MetricOnly:
+            return _MetricOnly(overlap=1.0)
+
+        assert tracker.score_names() == ["tracker.overlap"]
+
+    def test_verdict_only_accepted(self) -> None:
+        @evaluator
+        def verdict(ctx: EvalContext) -> _VerdictOnly:
+            return _VerdictOnly(ok=True)
+
+        assert verdict.score_names() == ["verdict.ok"]
+
+    def test_reason_only_accepted(self) -> None:
+        @evaluator
+        def reason(ctx: EvalContext) -> _ReasonOnly:
+            return _ReasonOnly(why="because")
+
+        assert reason.score_names() == ["reason.why"]
+
+    def test_annotated_field_alongside_metadata_accepted(self) -> None:
+        @evaluator
+        def mixed(ctx: EvalContext) -> _AnnotatedPlusMetadata:
+            return _AnnotatedPlusMetadata(ok=True, debug={})
+
+        assert mixed.score_names() == ["mixed.ok"]


### PR DESCRIPTION
## What

Closes #125.

`extract_scores_from_result` only emits scores for `Metric`/`Verdict`/`Reason`-annotated fields. An evaluator returning a dataclass with **none** of those produces `extract_scores_from_result(...) == []`. If every evaluator on a case is in that state, `scores == []` and `passed = all([])` is `True` — an always-green eval that slips through the `NoEvaluatorsError` guard, because that guard counts *evaluators*, not *scores*.

## Change

`_validate_return_annotation` already inspects the return dataclass at decoration time (to derive stable score names). It now also requires at least one annotated field there, failing loud at the boundary — consistent with the return-annotation contract.

Per the issue's "to decide" note: the check requires at least one field of **any** scored kind (`Metric`/`Verdict`/`Reason`), not specifically a `Verdict`. This keeps tracking-only evaluators (metrics-only, like `word_overlap`) and reason-only evaluators valid — they still emit a score, so they don't pass vacuously.

## Tests

`tests/evals/test_evaluator_validation.py` — new `TestDataclassReturnMustHaveAnnotatedField`:
- zero annotated fields → `TypeError` at decoration;
- metric-only / verdict-only / reason-only dataclasses accepted;
- annotated field alongside unannotated free metadata accepted.

Docs: `docs/evals.md` updated to state the requirement.

Full suite: **1246 passed**, `ruff` clean, `mypy --strict` clean. No existing builtin or test returns a zero-annotated-field dataclass, so nothing else changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E81dXJTPBNXxPrAomigKnf)_