### PR TITLE
ci(publish): publish on release, drop PARKED note

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,28 +1,15 @@
 name: Publish to PyPI
 
 # -----------------------------------------------------------------------------
-# PARKED - manual trigger only.
-#
-# The distribution name 'apte' is available on PyPI, so the old blocker (the
-# 'protest' name was taken, PEP 541 reclaim pending) is gone. This workflow
-# stays on workflow_dispatch only until the PyPI Trusted Publisher is configured,
-# so a release never triggers a failing publish.
-#
-# To ACTIVATE once the Trusted Publisher exists:
-#   1. On PyPI, add a Trusted Publisher (or a pending publisher for the brand-new
-#      'apte' project):
-#        owner=renaudcepre, repo=<github repo>, workflow=publish.yml, environment=pypi
-#      Note: 'repo' must match the actual GitHub repo slug. The repo is still
-#      named 'protest' until renamed to 'apte'; configure the publisher with
-#      whatever the slug is at that point.
-#   2. Add the release trigger below:
-#        on:
-#          release:
-#            types: [published]   # release-please publishes the GitHub release
-#          workflow_dispatch:
+# Publishes apte to PyPI via Trusted Publishing (OIDC, no stored API token).
+# PyPI Trusted Publisher: owner=renaudcepre, repo=apte, workflow=publish.yml.
+# Fires on every published GitHub release (release-please cuts these) and can
+# also be run manually.
 # -----------------------------------------------------------------------------
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,5 +1,15 @@
 # JOURNAL
 
+## 2026-06-25 — ci(publish): apte publie sur PyPI, trigger release cable
+
+Trusted Publisher PyPI configure (pending publisher : repo=renaudcepre/apte,
+workflow=publish.yml, environment laisse sur "Any"). apte 0.3.0 publie via
+workflow_dispatch manuel (build depuis main = 0.3.0), OIDC, sans token stocke.
+Verifie live : pypi.org/project/apte/ 200, `pip install apte` ok, nom reserve.
+
+publish.yml : bloc PARKED retire, trigger `release: [published]` ajoute (+ garde
+workflow_dispatch). Les prochaines releases release-please publieront automatiquement.
+
 ## 2026-06-24 — fix(assets): wordmark SVG protest -> apte
 
 Le rename texte n'avait pas touche les logos : le mot "protest" y est vectorise


### PR DESCRIPTION
Le Trusted Publisher PyPI pour `apte` est configuré et `apte 0.3.0` est déjà publiée (déclenchée manuellement). Le workflow n'a plus besoin de rester en manuel.

- Ajoute le trigger `release: [published]` : les prochaines releases release-please publieront automatiquement sur PyPI.
- Garde `workflow_dispatch` pour les déclenchements manuels.
- Retire le bloc commentaire PARKED (obsolète).