### PR TITLE
ci: run on push to main (fix stale red badge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,5 +1,14 @@
 # JOURNAL
 
+## 2026-06-25 — ci: run on push to main (badge CI rouge)
+
+Badge CI rouge sur la page PyPI : pas une regression. `ci.yml` ne se declenchait
+que sur `pull_request`, jamais sur push main, donc le badge fossilisait le dernier
+run push (un echec de mars 2026). Ajout du trigger `push: branches: [main]` : chaque
+merge relance la CI sur main et rafraichit le badge. Le code etait vert sur toutes
+les PRs. (Lie : les PRs release-please n'ont aucun check car les PRs du bot
+github-actions ne declenchent pas les workflows.)
+
 ## 2026-06-25 — ci(publish): apte publie sur PyPI, trigger release cable
 
 Trusted Publisher PyPI configure (pending publisher : repo=renaudcepre/apte,


### PR DESCRIPTION
Le badge CI affiché sur la page PyPI / le README était rouge alors que le code est sain.

Cause : `ci.yml` ne se déclenchait que sur `pull_request`, jamais sur push vers main. Le badge `ci.yml/badge.svg` reflète le dernier run sur la branche par défaut, resté figé sur un échec de mars 2026. Toutes les PRs récentes étaient vertes.

Fix : ajout du trigger `push: branches: [main]`. Chaque merge relance la CI sur main et met le badge à jour. Le merge de cette PR produira le premier run vert sur main.