### PR TITLE
fix(docs): install from PyPI in README

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,5 +1,13 @@
 # JOURNAL
 
+## 2026-06-25 — fix(docs): README install -> pip install apte
+
+La section Installation du README disait encore "not yet on PyPI, install from
+GitHub" alors que apte 0.3.0 est publie. Contradiction visible sur la page PyPI
+(le README est la description). Bascule sur `uv add apte` / `pip install apte`.
+Commit en `fix:` exprès : la description PyPI est figee a la publication, il faut
+une 0.3.1 (release-please + auto-publish) pour rafraichir la page en ligne.
+
 ## 2026-06-25 — ci: run on push to main (badge CI rouge)
 
 Badge CI rouge sur la page PyPI : pas une regression. `ci.yml` ne se declenchait

--- a/README.md
+++ b/README.md
@@ -118,14 +118,12 @@ apte run test_sample:session
 
 ## Installation
 
-Apte is not yet on PyPI. Install directly from GitHub:
-
 ```bash
 # With uv (recommended)
-uv add git+https://github.com/renaudcepre/apte.git
+uv add apte
 
 # With pip
-pip install git+https://github.com/renaudcepre/apte.git
+pip install apte
 ```
 
 ## CLI


### PR DESCRIPTION
Le README (= description PyPI) disait encore `Apte is not yet on PyPI` avec une install `git+https`, alors que `apte 0.3.0` est publié. Contradiction visible en haut de la page PyPI.

Bascule sur `uv add apte` / `pip install apte`.

Commit en `fix:` volontairement : la description PyPI est figée à la publication, il faut une 0.3.1 (release-please -> auto-publish) pour rafraîchir la page en ligne avant de partager le lien.