### PR TITLE
ci: make auto-publish to PyPI actually work

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,13 +3,15 @@ name: Publish to PyPI
 # -----------------------------------------------------------------------------
 # Publishes apte to PyPI via Trusted Publishing (OIDC, no stored API token).
 # PyPI Trusted Publisher: owner=renaudcepre, repo=apte, workflow=publish.yml.
-# Fires on every published GitHub release (release-please cuts these) and can
-# also be run manually.
+#
+# Triggered by the Release Please workflow, which dispatches this one when it cuts
+# a release. We can't use `on: release` here: release-please creates the GitHub
+# release with GITHUB_TOKEN, and events from that token don't trigger workflows
+# (recursion prevention). workflow_dispatch is exempt from that rule. Can also be
+# run manually.
 # -----------------------------------------------------------------------------
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,13 +8,25 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write # to dispatch publish.yml when a release is cut
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please cuts the GitHub release with GITHUB_TOKEN, which does not
+      # trigger `on: release` workflows (recursion prevention). workflow_dispatch
+      # is exempt, so dispatch the publish workflow explicitly. publish.yml stays
+      # the entry workflow, so the PyPI Trusted Publisher config is unchanged.
+      - name: Trigger PyPI publish
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish.yml --ref main --repo ${{ github.repository }}

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,5 +1,22 @@
 # JOURNAL
 
+## 2026-06-25 — ci: auto-publish reel (dispatch depuis release-please)
+
+Le trigger `release: [published]` ajoute plus tot etait inoperant : release-please
+cree la GitHub Release avec le GITHUB_TOKEN, et GitHub ne declenche aucun workflow
+sur un evenement emis par ce token (anti-recursion). 0.3.0 et 0.3.1 ont du etre
+publiees a la main.
+
+Verifie sur les sources (changelog GitHub 2022-09-08, doc PyPI, README
+release-please-action) plutot que de deviner : `workflow_dispatch` est l'EXCEPTION
+a l'anti-recursion, il declenche bien un run via GITHUB_TOKEN. Et `release_created`
+(singulier) est le bon output pour un composant racine.
+
+Fix : release-please.yml fait `gh workflow run publish.yml` quand `release_created`
+est vrai (+ permission `actions: write`). publish.yml reste le workflow d'entree
+(claim OIDC = publish.yml, config Trusted Publisher PyPI inchangee) ; son trigger
+`release:` trompeur est retire. Les prochaines releases publieront vraiment seules.
+
 ## 2026-06-25 — fix(docs): README install -> pip install apte
 
 La section Installation du README disait encore "not yet on PyPI, install from


### PR DESCRIPTION
Le trigger `release: [published]` ajouté en #139 ne se déclenche jamais : release-please crée la GitHub Release avec le `GITHUB_TOKEN`, et GitHub ne lance aucun workflow sur un événement émis par ce token (anti-récursion). 0.3.0 et 0.3.1 ont dû être publiées manuellement.

Vérifié sur les sources ([changelog GitHub](https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/), [doc PyPI](https://docs.pypi.org/trusted-publishers/using-a-publisher/), [README release-please-action](https://github.com/googleapis/release-please-action)) :
- `workflow_dispatch` est l'**exception** à l'anti-récursion : il déclenche bien un run via GITHUB_TOKEN.
- `release_created` (singulier) est le bon output pour un composant racine.

Fix : `release-please.yml` fait `gh workflow run publish.yml` quand `release_created` est vrai (+ permission `actions: write`). `publish.yml` reste le workflow d'entrée (claim OIDC = `publish.yml`, config Trusted Publisher inchangée) ; son trigger `release:` trompeur est retiré.