### PR TITLE
perf(events): run sync handlers inline, cache async-ness, fix soft-stop race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ web/node_modules/
 /htmlcov/
 _sandbox/
 site/
+
+# Private work journal, kept local only
+JOURNAL.md

--- a/apte/core/execution/parallel.py
+++ b/apte/core/execution/parallel.py
@@ -175,8 +175,16 @@ class ParallelExecutor:
                 ctx.queue.task_done()
 
     def _should_stop(self, exitfirst_flag: asyncio.Event | None) -> bool:
-        """Check if execution should stop (interrupt or exitfirst)."""
-        return self._interrupt_handler.soft_stop_event.is_set() or (
+        """Check if execution should stop (interrupt or exitfirst).
+
+        Reads the synchronous interrupt state, not soft_stop_event: the event is
+        armed via call_soon_threadsafe (one loop iteration late), but _state is
+        set the instant the signal handler runs. Between two tests the scheduler
+        can reach this check without yielding to the loop (sync handlers run
+        inline, so emit() never suspends), so the event may still be unset while
+        a stop is already pending.
+        """
+        return self._interrupt_handler.should_stop_new_tests or (
             exitfirst_flag is not None and exitfirst_flag.is_set()
         )
 

--- a/apte/events/bus.py
+++ b/apte/events/bus.py
@@ -27,6 +27,9 @@ class _RegisteredHandler:
     func: Callable[..., Any]
     name: str
     blocking: bool = False
+    # Computed once at registration: a handler's async-ness never changes, and
+    # asyncio.iscoroutinefunction is costly (unwraps partials, inspects flags).
+    is_async: bool = False
 
 
 class EventBus:
@@ -102,7 +105,12 @@ class EventBus:
         """
         name = get_callable_name(handler)
         self._handlers[event].append(
-            _RegisteredHandler(func=handler, name=name, blocking=blocking)
+            _RegisteredHandler(
+                func=handler,
+                name=name,
+                blocking=blocking,
+                is_async=asyncio.iscoroutinefunction(handler),
+            )
         )
 
     def off(self, event: Event, handler: Callable[..., Any]) -> None:
@@ -121,7 +129,7 @@ class EventBus:
         for handler_entry in self._handlers[event]:
             handler = handler_entry.func
             handler_name = handler_entry.name
-            is_async = asyncio.iscoroutinefunction(handler)
+            is_async = handler_entry.is_async
 
             await self._emit_handler_start(handler_name, event, is_async)
             start_time = time.perf_counter()
@@ -191,10 +199,13 @@ class EventBus:
         self, name: str, event: Event, is_async: bool
     ) -> None:
         """Emit HANDLER_START without triggering handler events (avoid recursion)."""
+        listeners = self._handlers[Event.HANDLER_START]
+        if not listeners:
+            return
         info = HandlerInfo(name=name, event=event, is_async=is_async)
-        for handler_entry in self._handlers[Event.HANDLER_START]:
+        for handler_entry in listeners:
             try:
-                if asyncio.iscoroutinefunction(handler_entry.func):
+                if handler_entry.is_async:
                     await handler_entry.func(info)
                 else:
                     handler_entry.func(info)
@@ -210,12 +221,15 @@ class EventBus:
         error: Exception | None,
     ) -> None:
         """Emit HANDLER_END without triggering handler events (avoid recursion)."""
+        listeners = self._handlers[Event.HANDLER_END]
+        if not listeners:
+            return
         info = HandlerInfo(
             name=name, event=event, is_async=is_async, duration=duration, error=error
         )
-        for handler_entry in self._handlers[Event.HANDLER_END]:
+        for handler_entry in listeners:
             try:
-                if asyncio.iscoroutinefunction(handler_entry.func):
+                if handler_entry.is_async:
                     await handler_entry.func(info)
                 else:
                     handler_entry.func(info)
@@ -237,7 +251,7 @@ class EventBus:
         for handler_entry in self._handlers[event]:
             handler = handler_entry.func
             try:
-                if asyncio.iscoroutinefunction(handler):
+                if handler_entry.is_async:
                     result = await handler(data)
                 else:
                     result = handler(data)

--- a/apte/events/bus.py
+++ b/apte/events/bus.py
@@ -26,12 +26,19 @@ class _RegisteredHandler:
 
     func: Callable[..., Any]
     name: str
+    blocking: bool = False
 
 
 class EventBus:
     """Decoupled event dispatch with async support.
 
-    Sync handlers are executed in a thread pool (blocking the event emission).
+    Sync handlers run inline on the event loop by default: they are expected to
+    be fast and non-blocking (reporters buffering, result collection). Inline
+    dispatch avoids a thread-pool round-trip (socket + loop wakeup) per call,
+    which otherwise dominates the per-test cost. Handlers that genuinely block
+    (heavy disk/network work) opt in with `on(..., blocking=True)` to be
+    offloaded to the thread pool instead.
+
     Async handlers run fire-and-forget and are tracked for cleanup.
 
     Use wait_pending() before session end to ensure all async handlers complete.
@@ -84,10 +91,19 @@ class EventBus:
                 else:
                     handler()
 
-    def on(self, event: Event, handler: Callable[..., Any]) -> None:
-        """Register a handler for an event."""
+    def on(
+        self, event: Event, handler: Callable[..., Any], *, blocking: bool = False
+    ) -> None:
+        """Register a handler for an event.
+
+        Sync handlers run inline by default. Pass `blocking=True` for sync
+        handlers that perform heavy blocking work and must not stall the loop;
+        those are offloaded to the thread pool.
+        """
         name = get_callable_name(handler)
-        self._handlers[event].append(_RegisteredHandler(func=handler, name=name))
+        self._handlers[event].append(
+            _RegisteredHandler(func=handler, name=name, blocking=blocking)
+        )
 
     def off(self, event: Event, handler: Callable[..., Any]) -> None:
         """Unregister a handler for an event."""
@@ -119,16 +135,21 @@ class EventBus:
                     )
                     self._pending_tasks.add(task)
                     task.add_done_callback(self._pending_tasks.discard)
-                else:
+                elif handler_entry.blocking:
+                    # Opt-in: offload genuinely blocking handlers to a thread,
+                    # serialized per owner to protect shared instance state.
                     lock = self._get_owner_lock(handler)
-                    if data is not None:
-                        await run_in_threadpool(
-                            self._run_sync_with_lock, lock, handler, data
-                        )
-                    else:
-                        await run_in_threadpool(
-                            self._run_sync_with_lock, lock, handler, None
-                        )
+                    await run_in_threadpool(
+                        self._run_sync_with_lock, lock, handler, data
+                    )
+                    duration = time.perf_counter() - start_time
+                    await self._emit_handler_end(
+                        handler_name, event, False, duration, None
+                    )
+                else:
+                    # Default: run inline. No thread, so no cross-thread race and
+                    # no lock needed; the call runs to completion on the loop.
+                    self._run_sync_with_lock(None, handler, data)
                     duration = time.perf_counter() - start_time
                     await self._emit_handler_end(
                         handler_name, event, False, duration, None
@@ -176,7 +197,7 @@ class EventBus:
                 if asyncio.iscoroutinefunction(handler_entry.func):
                     await handler_entry.func(info)
                 else:
-                    await run_in_threadpool(handler_entry.func, info)
+                    handler_entry.func(info)
             except Exception:
                 logger.exception("HANDLER_START listener %s failed", handler_entry.name)
 
@@ -197,7 +218,7 @@ class EventBus:
                 if asyncio.iscoroutinefunction(handler_entry.func):
                     await handler_entry.func(info)
                 else:
-                    await run_in_threadpool(handler_entry.func, info)
+                    handler_entry.func(info)
             except Exception:
                 logger.exception("HANDLER_END listener %s failed", handler_entry.name)
 
@@ -219,7 +240,7 @@ class EventBus:
                 if asyncio.iscoroutinefunction(handler):
                     result = await handler(data)
                 else:
-                    result = await run_in_threadpool(handler, data)
+                    result = handler(data)
                 if result is not None:
                     data = result
             except Exception:


### PR DESCRIPTION
## Problem

The event bus ran every sync handler through `run_in_threadpool`, i.e. a
thread-pool round-trip (socket + event-loop wakeup) per call. Profiling a suite
of trivial async tests showed ~288 such offloads per test, dominating a
~9 ms/test framework overhead. On real, fast test suites this made apte slower
than pytest, because the per-test overhead exceeded the actual test work.

## Changes

- **Run sync handlers inline by default.** Handlers are expected to be fast and
  non-blocking (reporters buffering, result collection). Handlers that genuinely
  block opt in with `on(..., blocking=True)` to keep the thread-pool offload.
  `HANDLER_START`/`HANDLER_END` meta-events and `emit_and_collect` also run inline.
- **Cache handler async-ness at registration.** `iscoroutinefunction` was
  recomputed on every dispatch (~289 calls/test); a handler's async-ness is
  fixed, so compute it once in `on()`. Also skip the meta-event emission when no
  listeners are registered (the common case).
- **Gate the soft-stop scheduler on the synchronous interrupt state.** Removing
  the per-handler offload removed the only `await` that suspended between tests,
  which exposed a latent race: `_should_stop` read `soft_stop_event`, an
  `asyncio.Event` armed via `call_soon_threadsafe` (one loop iteration late),
  so a SIGINT during a test could be missed and the next test would still start.
  `_should_stop` now reads `should_stop_new_tests` (`_state`), set the instant
  the signal is handled. Fixes flaky `test_soft_stop_prevents_pending_tests_from_starting`
  under Python 3.14 (stable at 3.12, ~30% failures at 3.14).

## Impact

- Per-test overhead ~9 ms -> ~0.4 ms (cProfile of 200 trivial async tests:
  3.85 s -> 0.18 s, ~21x).
- Measured on full third-party suites ported 1:1 to apte (asyncio backend),
  full process wall-clock:
  - httpx (1285 cases): ~1.14x slower -> **1.70x faster** than pytest.
  - starlette (505 cases): **1.75x faster** than pytest.
  - even sequential `-n1` is now faster than pytest on both.

## Validation

- Full apte test suite green (1264 passed at 3.12, 18 passed interrupt suite at 3.14).
- Flaky 3.14 interrupt test now 60/60 green.
- ruff + mypy clean.
- No public API change; `blocking` is an additive keyword on `EventBus.on`.
