### PR TITLE
ci(lint): keep Markdown out of ruff format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
           python-version: "3.12"
 
       - name: Check format
-        run: uvx ruff format --check .
+        run: uvx ruff@0.15.12 format --check .
 
       - name: Lint
-        run: uvx ruff check .
+        run: uvx ruff@0.15.12 check .
 
   types:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,11 @@ output-format = "concise"
 line-length = 88
 extend-exclude = []
 
+[tool.ruff.format]
+# ruff >= 0.16 formats Python code blocks inside Markdown by default and
+# inserts PEP 8 blank lines in every doc snippet. Docs stay hand-formatted.
+exclude = ["*.md"]
+
 [tool.ruff.lint]
 select = [
     "F", # Pyflakes


### PR DESCRIPTION
## Why

CI runs `uvx ruff` unpinned, so every ruff release can break CI with no code change. ruff 0.16 did, twice:

- `Check format`: it formats Python code blocks inside Markdown by default and inserts PEP 8 blank lines into every doc snippet, failing on 21 untouched `.md` files (#153 hit it)
- `Lint`: it enables RUF036 (29 sites, autofixable) and PLR0917 (12 functions, not autofixable)

`main` last passed on ruff 0.15.x.

## What

- `pyproject.toml`: `[tool.ruff.format] exclude = ["*.md"]`, doc snippets stay hand-formatted regardless of ruff version
- `ci.yml`: `uvx ruff@0.15.12`, the version used locally. Bumping ruff and adopting the new rules is a separate PR.

## Verified

`ruff@0.15.12 format --check .` and `ruff@0.15.12 check .` clean; `ruff@0.16.5 format --check .` clean with the exclude.

Merge this first, then #153 gets rebased on it.

https://claude.ai/code/session_017qxfAtbxBhFTZoaBAJKA3J
